### PR TITLE
Don't minify CSS and JS for test and dev environments [stage-1]

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ deployment:
   staging:
     branch: /(feature|fix|chore).*/
     commands:
-      - NODE_ENV=prod npm run build
+      - NODE_ENV=test npm run build
       - >
         STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
         if [ "$STAGE_ENV" != '' ]; then

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,10 +68,7 @@
           js: [sourcemaps.init(), uglify(), sourcemaps.write()]
         }),
         // Don't minify for staging.
-        usemin({
-          css: [sourcemaps.init(), sourcemaps.write()],
-          js: [sourcemaps.init(), sourcemaps.write()]
-        })
+        usemin({})
       ))
       .pipe(gulp.dest("dist/"));
   });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp": "~3.8.3",
     "gulp-bump": "~0.1.8",
     "gulp-html-replace": "^1.4.4",
+    "gulp-if": "^2.0.0",
     "gulp-jshint": "~1.5.5",
     "gulp-minify-css": "0.3.4",
     "gulp-rename": "~1.2.0",


### PR DESCRIPTION
Only minify CSS and JS and create source maps if environment is `prod`.

To ensure the Storage modal always works on Production, use `prod.js` as the config file, except when the environment is `dev`.