### PR TITLE
Use real company ID for storage folder tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,6 @@ dependencies:
     - if [ -z $(grep version package.json |grep -o '[0-9.]*') ]; then echo Version must be specified in package.json; exit 1; fi
     - if [[ ! -d $HOME/aws ]]; then curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && unzip awscli-bundle.zip && sudo ./awscli-bundle/install -i $HOME/aws; fi
     - npm install -g gulp
-    - npm install -g casperjs@1.1.0-beta3
   post:
     - bower install
 test:

--- a/test/data/storage-folder.js
+++ b/test/data/storage-folder.js
@@ -9,10 +9,10 @@
       "selector": {
         "selection": "single-folder",
         "storageName": "images/",
-        "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?prefix=images%2F"
+        "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o?prefix=images%2F"
       },
       "storage": {
-        "companyId": "abc123",
+        "companyId": "b428b4e8-c8b9-41d5-8a10-b4193c789443",
         "folder": "images/",
         "fileName": ""
       },

--- a/test/integration/storage-folder.html
+++ b/test/integration/storage-folder.html
@@ -100,7 +100,7 @@
       });
 
       test("should set companyid attribute of storage component", function() {
-        assert.equal(storage.companyid, "abc123");
+        assert.equal(storage.companyid, "b428b4e8-c8b9-41d5-8a10-b4193c789443");
       });
 
       test("should set env attribute of storage component", function() {


### PR DESCRIPTION
* Use real company ID for storage folder tests
* Get rid of Casper install as we're not using it