### PR TITLE
Use images from Production Storage in tests [stage-1]

### DIFF
--- a/test/data/storage-file.js
+++ b/test/data/storage-file.js
@@ -8,13 +8,13 @@
       "url": "",
       "selector": {
         "selection": "single-file",
-        "storageName": "Widgets/simpson's.jpg",
-        "url": "https://storage.googleapis.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets%2Fsimpson's.jpg"
+        "storageName": "widget-testing/image-widget/Gone_Girl_Book_Cover.jpg",
+        "url": "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing%2Fimage-widget%2FGone_Girl_Book_Cover.jpg"
       },
       "storage": {
-        "folder": "Widgets",
-        "fileName": "simpson's.jpg",
-        "companyId": "b428b4e8-c8b9-41d5-8a10-b4193c789443"
+        "folder": "widget-testing/image-widget/",
+        "fileName": "Gone_Girl_Book_Cover.jpg",
+        "companyId": "30007b45-3df0-4c7b-9f7f-7d8ce6443013"
       },
       "resume": true,
       "scaleToFit": true,

--- a/test/data/storage-folder.js
+++ b/test/data/storage-folder.js
@@ -8,12 +8,12 @@
       "url": "",
       "selector": {
         "selection": "single-folder",
-        "storageName": "images/",
-        "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o?prefix=images%2F"
+        "storageName": "widget-testing/image-widget/",
+        "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o?prefix=widget-testing%2Fimage-widget%2F"
       },
       "storage": {
-        "companyId": "b428b4e8-c8b9-41d5-8a10-b4193c789443",
-        "folder": "images/",
+        "companyId": "30007b45-3df0-4c7b-9f7f-7d8ce6443013",
+        "folder": "widget-testing/image-widget/",
         "fileName": ""
       },
       "resume": true,

--- a/test/integration/storage-file.html
+++ b/test/integration/storage-file.html
@@ -28,7 +28,7 @@
 
 <script src="../../src/components/widget-common/dist/config.js"></script>
 <script src="../../src/components/widget-common/dist/rise-cache.js"></script>
-<script src="../../src/config/test.js"></script>
+<script src="../../src/config/config.js"></script>
 <script src="../../src/widget/image.js"></script>
 <script src="../../src/widget/storage-file.js"></script>
 <script src="../../src/components/widget-common/dist/message.js"></script>
@@ -38,55 +38,58 @@
   suite("storage - file", function() {
 
     var storage = document.querySelector("rise-storage"),
+      spy = sinon.spy(RiseVision.Image, "setAdditionalParams"),
       responded = false,
+      refreshSpy = null,
       listener;
 
     sinon.stub(storage.$.ping, "generateRequest", function () {
       storage._handlePingError();
     });
 
-    sinon.stub(storage, "_getStorageSubscription", function () {
-      storage._computeStorageUrl();
-      storage._loadStorage();
-    });
+    // No need to make requests to Storage via the component since events are triggered manually
+    // for these test cases.
+    sinon.stub(storage, "_getStorageSubscription", function () {});
 
     suite("file added", function () {
       var check = function(done) {
-          if (responded) {
-            done();
-          }
-          else {
-            setTimeout(function() {
-              check(done)
-            }, 1000);
-          }
-        };
+        if (spy && spy.calledOnce) {
+          storage.dispatchEvent(new CustomEvent("rise-storage-response", {
+            "detail": {
+              "added": true,
+              "name": "widget-testing/image-widget/Gone_Girl_Book_Cover.jpg",
+              "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGone_Girl_Book_Cover.jpg?alt=media"
+            },
+            "bubbles": true
+          }));
 
-      suiteSetup(function() {
-        listener = function(response) {
-          responded = true;
-          storage.removeEventListener("rise-storage-response", listener);
-        };
+          done();
+        }
+        else {
+          setTimeout(function() {
+            check(done)
+          }, 1000);
+        }
+      };
 
-        storage.addEventListener("rise-storage-response", listener);
-
-      });
-
-      // Don't run the tests until rise-storage-response has fired.
-      setup(function (done) {
+      suiteSetup(function(done) {
         check(done);
       });
 
+      suiteTeardown(function() {
+        RiseVision.Image.setAdditionalParams.restore();
+      });
+
       test("should set folder attribute of storage component", function() {
-        assert.equal(storage.folder, "Widgets");
+        assert.equal(storage.folder, "widget-testing/image-widget/");
       });
 
       test("should set filename attribute of storage component", function() {
-        assert.equal(storage.filename, "simpson's.jpg");
+        assert.equal(storage.filename, "Gone_Girl_Book_Cover.jpg");
       });
 
       test("should set companyid attribute of storage component", function() {
-        assert.equal(storage.companyid, "b428b4e8-c8b9-41d5-8a10-b4193c789443");
+        assert.equal(storage.companyid, "30007b45-3df0-4c7b-9f7f-7d8ce6443013");
       });
 
       test("should set env attribute of storage component", function() {
@@ -103,39 +106,45 @@
 
       test("should set background image", function() {
         assert.equal(document.getElementById("image").style.backgroundImage,
-          'url(\"https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/Widgets%2Fsimpson\'s.jpg?alt=media\")');
+          'url(\"https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGone_Girl_Book_Cover.jpg?alt=media\")');
       });
     });
 
     suite("file changed", function() {
+      setup(function() {
+        refreshSpy = sinon.spy(RiseVision.Image, "onFileRefresh");
+      })
+
+      teardown(function() {
+        RiseVision.Image.onFileRefresh.restore();
+      });
 
       test("should call onFileRefresh() and set background image", function() {
-        var onRefreshSpy = sinon.spy(RiseVision.Image, "onFileRefresh");
-
         storage.dispatchEvent(new CustomEvent("rise-storage-response", {
           "detail": {
             "changed": true,
-            "name": "Widgets/simpson's.jpg",
-            "url": "https://storage.googleapis.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets%2Fsimpson's.jpg"
+            "name": "widget-testing/image-widget/Gone_Girl_Book_Cover.jpg",
+            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGone_Girl_Book_Cover.jpg?alt=media&cb=0"
           },
           "bubbles": true
         }));
 
-        assert(onRefreshSpy.calledOnce);
-
+        assert(refreshSpy.calledOnce);
         assert.equal(document.getElementById("image").style.backgroundImage,
-          'url(\"https://storage.googleapis.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets%2Fsimpson\'s.jpg\")');
+          'url(\"https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGone_Girl_Book_Cover.jpg?alt=media&cb=0\")');
+      });
+    });
 
+    suite("file name/url changed (quotes)", function() {
+      setup(function() {
+        refreshSpy = sinon.spy(RiseVision.Image, "onFileRefresh");
+      })
+
+      teardown(function() {
         RiseVision.Image.onFileRefresh.restore();
       });
 
-    });
-
-    suite("file name/url changed (no quotes)", function() {
-
       test("should call onFileRefresh() and set background image", function() {
-        var onRefreshSpy = sinon.spy(RiseVision.Image, "onFileRefresh");
-
         storage.dispatchEvent(new CustomEvent("rise-storage-response", {
           "detail": {
             "changed": true,
@@ -145,20 +154,22 @@
           "bubbles": true
         }));
 
-        assert(onRefreshSpy.calledOnce);
-
+        assert(refreshSpy.calledOnce);
         assert.equal(document.getElementById("image").style.backgroundImage,
           'url("https://storage.googleapis.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/Widgets%2Fsimpsons.jpg")');
-
-        RiseVision.Image.onFileRefresh.restore();
       });
     });
 
     suite("file unchanged", function() {
+      setup(function() {
+        refreshSpy = sinon.spy(RiseVision.Image, "onFileRefresh");
+      })
+
+      teardown(function() {
+        RiseVision.Image.onFileRefresh.restore();
+      });
 
       test("should not call onFileRefresh() when file has not changed", function() {
-        var onRefreshSpy = sinon.spy(RiseVision.Image, "onFileRefresh");
-
         storage.dispatchEvent(new CustomEvent("rise-storage-response", {
           "detail": {
             "changed": false,
@@ -168,9 +179,7 @@
           "bubbles": true
         }));
 
-        assert(onRefreshSpy.notCalled);
-
-        RiseVision.Image.onFileRefresh.restore();
+        assert(refreshSpy.notCalled);
       });
 
     });
@@ -276,10 +285,15 @@
     });
 
     suite("Network Recovery", function () {
+      setup(function() {
+        refreshSpy = sinon.spy(RiseVision.Image, "onFileRefresh");
+      })
+
+      teardown(function() {
+        RiseVision.Image.onFileRefresh.restore();
+      });
 
       test("should call onFileRefresh() if in state of storage error and network recovered", function() {
-        var onRefreshSpy = sinon.spy(RiseVision.Image, "onFileRefresh");
-
         // force a storage error in the scenario of a network failure
         storage.dispatchEvent(new CustomEvent("rise-storage-error", {
           "detail": {
@@ -301,9 +315,7 @@
           "bubbles": true
         }));
 
-        assert(onRefreshSpy.calledOnce);
-
-        RiseVision.Image.onFileRefresh.restore();
+        assert(refreshSpy.calledOnce);
       });
     });
 

--- a/test/integration/storage-folder.html
+++ b/test/integration/storage-folder.html
@@ -36,7 +36,7 @@
 <script src="../../src/components/widget-common/dist/config.js"></script>
 <script src="../../src/components/widget-common/dist/rise-cache.js"></script>
 <script src="../../src/components/widget-common/dist/common.js"></script>
-<script src="../../src/config/test.js"></script>
+<script src="../../src/config/config.js"></script>
 <script src="../../src/widget/image.js"></script>
 <script src="../../src/widget/slider.js"></script>
 <script src="../../src/widget/storage-folder.js"></script>
@@ -44,7 +44,6 @@
 <script src="../../src/widget/main.js"></script>
 
 <script>
-
   suite("storage - folder", function() {
     var storage = document.querySelector("rise-storage"),
       spy = sinon.spy(RiseVision.Image, "setAdditionalParams");
@@ -53,14 +52,18 @@
       storage._handlePingError();
     });
 
+    // No need to make requests to Storage via the component since events are triggered manually
+    // for these test cases.
+    sinon.stub(storage, "_getStorageSubscription", function () {});
+
     suite("initialize", function () {
       var check = function(done) {
         if (spy && spy.calledOnce) {
           storage.dispatchEvent(new CustomEvent("rise-storage-response", {
             "detail": {
               "added": true,
-              "name": "images/Gone_Girl_Book_Cover.jpg",
-              "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FGone_Girl_Book_Cover.jpg?alt=media"
+              "name": "widget-testing/image-widget/Gone_Girl_Book_Cover.jpg",
+              "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGone_Girl_Book_Cover.jpg?alt=media"
             },
             "bubbles": true
           }));
@@ -68,8 +71,8 @@
           storage.dispatchEvent(new CustomEvent("rise-storage-response", {
             "detail": {
               "added": true,
-              "name": "images/Gated_Book_Cover.jpg",
-              "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FGated_Book_Cover.jpg?alt=media"
+              "name": "widget-testing/image-widget/Gated_Book_Cover.jpg",
+              "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGated_Book_Cover.jpg?alt=media"
             },
             "bubbles": true
           }));
@@ -96,11 +99,11 @@
       });
 
       test("should set folder attribute of storage component", function() {
-        assert.equal(storage.folder, "images/");
+        assert.equal(storage.folder, "widget-testing/image-widget/");
       });
 
       test("should set companyid attribute of storage component", function() {
-        assert.equal(storage.companyid, "b428b4e8-c8b9-41d5-8a10-b4193c789443");
+        assert.equal(storage.companyid, "30007b45-3df0-4c7b-9f7f-7d8ce6443013");
       });
 
       test("should set env attribute of storage component", function() {
@@ -128,9 +131,9 @@
       });
 
       test("should add images in alphabetical order", function() {
-        assert.equal(document.querySelector(".tp-revslider-mainul .tp-revslider-slidesli:nth-child(1) .tp-bgimg").getAttribute("src"), "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FGated_Book_Cover.jpg?alt=media", "first slide");
+        assert.equal(document.querySelector(".tp-revslider-mainul .tp-revslider-slidesli:nth-child(1) .tp-bgimg").getAttribute("src"), "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGated_Book_Cover.jpg?alt=media", "first slide");
 
-        assert.equal(document.querySelector(".tp-revslider-mainul .tp-revslider-slidesli:nth-child(2) .tp-bgimg").getAttribute("src"), "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FGone_Girl_Book_Cover.jpg?alt=media", "second slide");
+        assert.equal(document.querySelector(".tp-revslider-mainul .tp-revslider-slidesli:nth-child(2) .tp-bgimg").getAttribute("src"), "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGone_Girl_Book_Cover.jpg?alt=media", "second slide");
       });
 
     });
@@ -140,7 +143,7 @@
         storage.dispatchEvent(new CustomEvent("rise-storage-response", {
           "detail": {
             "added": true,
-            "name": "images/The_Girl_On_The_Train_Cover.jpg",
+            "name": "widget-testing/image-widget/The_Girl_On_The_Train_Cover.jpg",
             "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FThe_Girl_On_The_Train_Cover.jpg?alt=media"
           },
           "bubbles": true
@@ -161,8 +164,8 @@
         storage.dispatchEvent(new CustomEvent("rise-storage-response", {
           "detail": {
             "changed": true,
-            "name": "images/Gated_Book_Cover.jpg",
-            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FGated_Book_Cover.jpg?alt=media&cb=0"
+            "name": "widget-testing/image-widget/Gated_Book_Cover.jpg",
+            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGated_Book_Cover.jpg?alt=media&cb=0"
           },
           "bubbles": true
         }));
@@ -171,7 +174,7 @@
       test("should update image", function(done) {
         setTimeout(function() {
           assert.equal(document.querySelectorAll(".tp-revslider-mainul .tp-revslider-slidesli").length, 3, "num of slides");
-          assert.equal(document.querySelector(".tp-revslider-mainul .tp-revslider-slidesli:nth-child(1) .tp-bgimg").getAttribute("src"), "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FGated_Book_Cover.jpg?alt=media&cb=0");
+          assert.equal(document.querySelector(".tp-revslider-mainul .tp-revslider-slidesli:nth-child(1) .tp-bgimg").getAttribute("src"), "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGated_Book_Cover.jpg?alt=media&cb=0");
           done();
         }, 8000);
       });
@@ -186,8 +189,8 @@
         storage.dispatchEvent(new CustomEvent("rise-storage-response", {
           "detail": {
             "changed": false,
-            "name": "images/Gated_Book_Cover.jpg",
-            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FGated_Book_Cover.jpg?alt=media&cb=0"
+            "name": "widget-testing/image-widget/Gated_Book_Cover.jpg",
+            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGated_Book_Cover.jpg?alt=media&cb=0"
           },
           "bubbles": true
         }));
@@ -208,8 +211,8 @@
         storage.dispatchEvent(new CustomEvent("rise-storage-response", {
           "detail": {
             "deleted": true,
-            "name": "images/Gated_Book_Cover.jpg",
-            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FGated_Book_Cover.jpg?alt=media&cb=0"
+            "name": "widget-testing/image-widget/Gated_Book_Cover.jpg",
+            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGated_Book_Cover.jpg?alt=media&cb=0"
           },
           "bubbles": true
         }));
@@ -218,14 +221,13 @@
       test("should delete image", function(done) {
         setTimeout(function() {
           assert.equal(document.querySelectorAll(".tp-revslider-mainul .tp-revslider-slidesli").length, 2, "number of slides");
-          assert.equal(document.querySelector(".tp-revslider-mainul .tp-revslider-slidesli:nth-child(1) .tp-bgimg").getAttribute("src"), "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FGone_Girl_Book_Cover.jpg?alt=media", "slide");
+          assert.equal(document.querySelector(".tp-revslider-mainul .tp-revslider-slidesli:nth-child(1) .tp-bgimg").getAttribute("src"), "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGone_Girl_Book_Cover.jpg?alt=media", "slide");
           done();
         }, 5000);
       });
     });
 
     suite("network recovery", function () {
-
       test("should call onFileRefresh() if in state of storage error and network recovered", function() {
         var onRefreshStub = sinon.stub(RiseVision.Image, "onFileRefresh", function(){});
 
@@ -244,8 +246,8 @@
         storage.dispatchEvent(new CustomEvent("rise-storage-response", {
           "detail": {
             "changed": false,
-            "name": "images/Gated_Book_Cover.jpg",
-            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/o/images%2FGated_Book_Cover.jpg?alt=media&cb=0"
+            "name": "widget-testing/image-widget/Gated_Book_Cover.jpg",
+            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/widget-testing%2Fimage-widget%2FGated_Book_Cover.jpg?alt=media&cb=0"
           },
           "bubbles": true
         }));
@@ -257,7 +259,6 @@
     });
 
   });
-
 </script>
 </body>
 </html>


### PR DESCRIPTION
Although the tests are passing now when not being watched, I am not convinced that the Storage folder tests will pass consistently. And that's due to [this Selenium issue](http://goo.gl/X3AO17). I can reproduce this locally by starting a web server, initiating the tests, and then moving away from the tab. The "should add image", "should update image" and "should delete image" tests will fail.

The Slider Revolution plugin that we use for the image slideshow does have code that looks for focus and blur events. When the browser window doesn't have the focus, the slideshow does not play, and the tests fail. I was not able to find a workaround in the code.

Having said that, the Storage file tests are more reliable now and all tests have passed consistently for on CCI the last 3 times. If the folder tests do fail in the future, the easiest solution is to keep the focus on the CCI tab.