### PR TITLE
Update rise-storage.html

### DIFF
--- a/dist/components/rise-storage/rise-storage.html
+++ b/dist/components/rise-storage/rise-storage.html
@@ -740,12 +740,12 @@
       this._hasAttemptedGetRequest = false;
 
       if (this._isLoading) {
-        this._cacheUrl = this._baseCacheUrl + "?url=" + this._fileUrl;
+        this._cacheUrl = this._baseCacheUrl + "?url=" + this._fileUrl + "&single=true";
       }
       else {
         // Include a cache buster as this will be the URL that gets passed to the browser
         // if the file has changed.
-        this._cacheUrl = this._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + this._fileUrl;
+        this._cacheUrl = this._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + this._fileUrl + "&single=true";
       }
 
       this.$.cache.generateRequest();


### PR DESCRIPTION
I wanted to add this as a special request for windows IOT. The image folder and single image acts differently on windows IOT than it does on a chrome player because iot uses edge. Dont know why its different but seems i have to send different headers for both to work. This &single=true will allow me to know which request is coming in when the cachebuster is called. A single image will have this on there. While the image folder will not. Please test this for me on your players to be sure this works. If it does please merge this in so that i can complete the Windows IOT caching side of things. Thanks
