### PR TITLE
Handling "rise-cache-not-running" event to show message when running in player

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.3.39",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.3.42",
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.13.0",
-    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.4.2",
+    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.4.3",
     "webcomponentsjs": "~0.7.11",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.2",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.1.2",

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.3.39",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.3.42",
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.13.0",
-    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.4.0",
+    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.4.2",
     "webcomponentsjs": "~0.7.11",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.2",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.1.2",

--- a/src/widget/storage-file.js
+++ b/src/widget/storage-file.js
@@ -138,10 +138,24 @@ RiseVision.Image.StorageFile = function( params, displayId ) {
       var params = {
         "event": "error",
         "event_details": "rise cache not running",
-        "error_details": ( e.detail && e.detail.error ) ? e.detail.error.message : ""
+        "error_details": ""
       };
 
+      if ( e.detail ) {
+        if ( e.detail.error ) {
+          // storage v1
+          params.error_details = e.detail.error.message;
+        } else if ( e.detail.resp && e.detail.resp.error ) {
+          // storage v2
+          params.error_details = e.detail.resp.error.message;
+        }
+      }
+
       RiseVision.Image.logEvent( params, true );
+
+      if ( e.detail && e.detail.isPlayerRunning ) {
+        RiseVision.Image.showError( "Waiting for Rise Cache", true );
+      }
     } );
 
     storage.addEventListener( "rise-cache-file-unavailable", function() {

--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -187,10 +187,24 @@ RiseVision.Image.StorageFolder = function( data, displayId ) {
       var params = {
         "event": "error",
         "event_details": "rise cache not running",
-        "error_details": ( e.detail && e.detail.error ) ? e.detail.error.message : ""
+        "error_details": ""
       };
 
+      if ( e.detail ) {
+        if ( e.detail.error ) {
+          // storage v1
+          params.error_details = e.detail.error.message;
+        } else if ( e.detail.resp && e.detail.resp.error ) {
+          // storage v2
+          params.error_details = e.detail.resp.error.message;
+        }
+      }
+
       RiseVision.Image.logEvent( params, true );
+
+      if ( e.detail && e.detail.isPlayerRunning ) {
+        RiseVision.Image.showError( "Waiting for Rise Cache", true );
+      }
     } );
 
     storage.setAttribute( "fileType", "image" );

--- a/test/integration/js/storage-file.js
+++ b/test/integration/js/storage-file.js
@@ -326,6 +326,46 @@ suite( "storage errors", function() {
       "showError() called with correct message" );
   } );
 
+  test( "should handle when a 'rise cache not running' occurs", function() {
+    params.event = "error";
+    params.event_details = "rise cache not running";
+    params.error_details = "The request failed with status code: 500";
+
+    delete params.file_url;
+
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 500"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      assert( onShowErrorStub.calledOnce, "showError() called once" );
+      assert( onShowErrorStub.calledWith( "Waiting for Rise Cache" ),
+        "showError() called with correct message" );
+
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 500"
+          }
+        },
+        "bubbles": true
+      } ) );
+    }
+
+    assert( onLogEventStub.calledOnce, "logEvent() called once" );
+    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+
+  } );
+
 } );
 
 suite( "Network Recovery", function() {

--- a/test/integration/js/storage-folder.js
+++ b/test/integration/js/storage-folder.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suite, suiteTeardown, test, assert, RiseVision, sinon, config */
+/* global requests, suiteSetup, suite, suiteTeardown, setup, teardown, test, assert, RiseVision, sinon, config */
 
 /* eslint-disable func-names */
 
@@ -214,5 +214,64 @@ suite( "network recovery", function() {
     assert( onRefreshStub.calledOnce );
 
     RiseVision.Image.onFileRefresh.restore();
+  } );
+} );
+
+suite( "storage errors", function() {
+  var params = { "event": "" },
+    onShowErrorStub,
+    onLogEventStub;
+
+  setup( function() {
+    onShowErrorStub = sinon.stub( RiseVision.Image, "showError", function() {} );
+    onLogEventStub = sinon.stub( RiseVision.Image, "logEvent", function() {} );
+  } );
+
+  teardown( function() {
+    delete params.url;
+    delete params.event_details;
+
+    RiseVision.Image.showError.restore();
+    RiseVision.Image.logEvent.restore();
+  } );
+
+  test( "should handle when a 'rise cache not running' occurs", function() {
+    params.event = "error";
+    params.event_details = "rise cache not running";
+    params.error_details = "The request failed with status code: 404";
+
+    delete params.file_url;
+
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      assert( onShowErrorStub.calledOnce, "showError() called once" );
+      assert( onShowErrorStub.calledWith( "Waiting for Rise Cache" ),
+        "showError() called with correct message" );
+
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 404"
+          }
+        },
+        "bubbles": true
+      } ) );
+    }
+
+    assert( onLogEventStub.calledOnce, "logEvent() called once" );
+    assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
+
   } );
 } );

--- a/test/integration/js/storage-logging-file.js
+++ b/test/integration/js/storage-logging-file.js
@@ -149,9 +149,19 @@ suite( "rise cache error", function() {
   test( "should log a rise cache not running when ping response is empty", function() {
     spy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 
-    storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", null ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": null,
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", null ) );
+    }
 
-    params.event = "error"
+    params.event = "error";
     params.event_details = "rise cache not running";
     params.error_details = "";
     delete params.file_url;
@@ -164,13 +174,28 @@ suite( "rise cache error", function() {
   test( "should log a rise cache not running when ping response is 404", function() {
     spy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 
-    storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
-      "detail": {
-        "error": {
-          "message": "The request failed with status code: 404"
-        } },
-      "bubbles": true
-    } ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 404"
+          }
+        },
+        "bubbles": true
+      } ) );
+    }
 
     params.event = "error";
     params.event_details = "rise cache not running";

--- a/test/integration/js/storage-logging-folder.js
+++ b/test/integration/js/storage-logging-folder.js
@@ -387,7 +387,17 @@ suite( "rise storage error", function() {
   test( "should log a rise cache not running when ping response is empty", function() {
     spy = sinon.spy( RiseVision.Common.Logger, "log" );
 
-    storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", null ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": null,
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", null ) );
+    }
 
     params.event = "error"
     params.event_details = "rise cache not running";
@@ -400,13 +410,28 @@ suite( "rise storage error", function() {
   test( "should log a rise cache not running when ping response is 404", function() {
     spy = sinon.spy( RiseVision.Common.Logger, "log" );
 
-    storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
-      "detail": {
-        "error": {
-          "message": "The request failed with status code: 404"
-        } },
-      "bubbles": true
-    } ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 404"
+          }
+        },
+        "bubbles": true
+      } ) );
+    }
 
     params.event = "error"
     params.event_details = "rise cache not running";

--- a/test/integration/js/storage-messaging-file.js
+++ b/test/integration/js/storage-messaging-file.js
@@ -276,3 +276,52 @@ suite( "cache file unavailable", function() {
     RiseVision.Image.play.restore();
   } );
 } );
+
+suite( "rise cache not running", function() {
+  test( "should show rise cache not running message using rise-storage v2", function() {
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      assert.equal( document.querySelector( ".message" ).innerHTML, "Waiting for Rise Cache", "message text" );
+      assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ), "message visibility" );
+    }
+  } );
+
+  test( "should call play function 5 seconds after a rise cache not running error using rise-storage v2", function() {
+    var clock = sinon.useFakeTimers(),
+      spy = sinon.spy( RiseVision.Image, "play" );
+
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      clock.tick( 4500 );
+      assert( spy.notCalled );
+      clock.tick( 500 );
+      assert( spy.calledOnce );
+
+      clock.restore();
+      RiseVision.Image.play.restore();
+    }
+
+  } );
+} );

--- a/test/integration/js/storage-messaging-folder.js
+++ b/test/integration/js/storage-messaging-folder.js
@@ -245,3 +245,52 @@ suite( "rise cache error", function() {
     RiseVision.Image.play.restore();
   } );
 } );
+
+suite( "rise cache not running", function() {
+  test( "should show rise cache not running message using rise-storage v2", function() {
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      assert.equal( document.querySelector( ".message" ).innerHTML, "Waiting for Rise Cache", "message text" );
+      assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ), "message visibility" );
+    }
+  } );
+
+  test( "should call play function 5 seconds after a rise cache not running error using rise-storage v2", function() {
+    var clock = sinon.useFakeTimers(),
+      spy = sinon.spy( RiseVision.Image, "play" );
+
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-not-running", {
+        "detail": {
+          "resp": {
+            "error": {
+              "message": "The request failed with status code: 404"
+            }
+          },
+          "isPlayerRunning": true
+        },
+        "bubbles": true
+      } ) );
+
+      clock.tick( 4500 );
+      assert( spy.notCalled );
+      clock.tick( 500 );
+      assert( spy.calledOnce );
+
+      clock.restore();
+      RiseVision.Image.play.restore();
+    }
+
+  } );
+} );


### PR DESCRIPTION
- Updating to use latest release of rise-storage v2 
- Conditionally populating `error_details` value in handler of `rise-storage` "rise cache not running" event based on `e.detail` object props
- Showing message "Waiting for Rise Cache" if `isPlayerRunning` present and `true` in handler of `rise-storage` "rise cache not running" event
- Added integration tests for file and folder scenarios