### PR TITLE
Added a background-image: none before setting a new url

### DIFF
--- a/src/widget/image.js
+++ b/src/widget/image.js
@@ -152,6 +152,7 @@ RiseVision.Image = ( function( gadgets ) {
     _img.onload = function() {
       var image = document.querySelector( "#container #image" );
 
+      image.style.backgroundImage = "none";
       image.style.backgroundImage = "url('" + url + "')";
       _isGif = url.indexOf( ".gif" ) === -1 ? false : true;
 


### PR DESCRIPTION
That will fix when a file is changed on storage but the name is kept the same

Fixing https://github.com/Rise-Vision/rise-cache-v2/issues/73

@stulees @donnapep please review. cheers