### PR TITLE
Fix RC urls in legacy rise-storage component [stage-2]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "angular-route": "~1.3.0",
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.3.39",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.3.42",
-    "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.13.0",
+    "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.13.1",
     "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.4.3",
     "webcomponentsjs": "~0.7.11",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.3",


### PR DESCRIPTION
- Use latest release of legacy v1 rise-storage