### PR TITLE
Fix subscription request error handling via rise-storage 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.3.39",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.3.42",
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.13.1",
-    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.4.5",
+    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#1.5.0",
     "webcomponentsjs": "~0.7.11",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.4",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.1.2",

--- a/src/widget/storage-file.js
+++ b/src/widget/storage-file.js
@@ -81,6 +81,16 @@ RiseVision.Image.StorageFile = function( params, displayId ) {
       RiseVision.Image.showError( "The selected image is temporarily unavailable." );
     } );
 
+    storage.addEventListener( "rise-storage-subscription-error", function( e ) {
+      var params = {
+        "event": "error",
+        "event_details": "storage subscription error",
+        "error_details": "The request failed with status code: " + e.detail.error.currentTarget.status
+      };
+
+      RiseVision.Image.logEvent( params, true );
+    } );
+
     storage.addEventListener( "rise-storage-subscription-expired", function() {
       var params = {
         "event": "error",

--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -138,6 +138,16 @@ RiseVision.Image.StorageFolder = function( data, displayId ) {
       RiseVision.Image.showError( "The selected folder does not contain any supported image formats." );
     } );
 
+    storage.addEventListener( "rise-storage-subscription-error", function( e ) {
+      var params = {
+        "event": "error",
+        "event_details": "storage subscription error",
+        "error_details": "The request failed with status code: " + e.detail.error.currentTarget.status
+      };
+
+      RiseVision.Image.logEvent( params, true );
+    } );
+
     storage.addEventListener( "rise-storage-subscription-expired", function() {
       var params = {
         "event": "error",

--- a/test/integration/js/storage-logging-file.js
+++ b/test/integration/js/storage-logging-file.js
@@ -437,8 +437,32 @@ suite( "storage subscription expired", function() {
     assert( spy.calledWith( table, params ) );
   } );
 
+  test( "should log a storage subscription error", function() {
+    spy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
+
+    storage.dispatchEvent( new CustomEvent( "rise-storage-subscription-error", {
+      "detail": {
+        "error": {
+          "currentTarget": {
+            "status": 0
+          }
+        }
+      },
+      "bubbles": true
+    } ) );
+
+    params.event_details = "storage subscription error";
+    params.error_details = "The request failed with status code: 0";
+
+    assert( spy.calledOnce );
+    assert( spy.calledWith( table, params ) );
+  } );
+
   test( "should log a storage subscription expired error when done is fired", function() {
     storage.dispatchEvent( new CustomEvent( "rise-storage-subscription-expired" ) );
+
+    params.event_details = "storage subscription expired";
+    delete params.error_details;
 
     spy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
     clock.tick( 5000 );

--- a/test/integration/js/storage-logging-folder.js
+++ b/test/integration/js/storage-logging-folder.js
@@ -468,8 +468,32 @@ suite( "storage subscription expired", function() {
     assert( spy.calledWith( table, params ) );
   } );
 
+  test( "should log a storage subscription error", function() {
+    spy = sinon.spy( RiseVision.Common.Logger, "log" );
+
+    storage.dispatchEvent( new CustomEvent( "rise-storage-subscription-error", {
+      "detail": {
+        "error": {
+          "currentTarget": {
+            "status": 0
+          }
+        }
+      },
+      "bubbles": true
+    } ) );
+
+    params.event_details = "storage subscription error";
+    params.error_details = "The request failed with status code: 0";
+
+    assert( spy.calledOnce );
+    assert( spy.calledWith( table, params ) );
+  } );
+
   test( "should log a storage subscription expired error when done is fired", function() {
     storage.dispatchEvent( new CustomEvent( "rise-storage-subscription-expired" ) );
+
+    params.event_details = "storage subscription expired";
+    delete params.error_details;
 
     spy = sinon.spy( RiseVision.Common.Logger, "log" );
     clock.tick( 5000 );


### PR DESCRIPTION
- Use latest `rise-storage` release to update handling of subscription request error
- Add missing handlers for "rise-storage-subscription-error" event from `rise-storage` 
- Added integration tests for logging