### PR TITLE
Send a WATCH of file from GCS and handle FILE-UPDATE for test purposes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.13.1",
     "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.0.9",
     "webcomponentsjs": "~0.7.11",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.5.1",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.6.0",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.3.1",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3"

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.13.1",
     "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.0.9",
     "webcomponentsjs": "~0.7.11",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.6.0",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.6.1",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.3.1",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3"

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "run-sequence": "^0.3.2",
     "web-component-tester": "5.0.0",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#1.7.3"
+  },
+  "optionalDependencies": {
+    "wct-local": "<2.0.16"
   }
 }

--- a/src/widget.html
+++ b/src/widget.html
@@ -41,6 +41,7 @@
   <script src="components/widget-common/dist/logger.js"></script>
   <script src="components/widget-common/dist/common.js"></script>
   <script src="components/widget-common/dist/rise-cache.js"></script>
+  <script src="components/widget-common/dist/ws-client.js"></script>
   <script src="config/version.js"></script>
   <script src="config/config.js"></script>
   <script src="widget/image.js"></script>

--- a/src/widget.html
+++ b/src/widget.html
@@ -50,6 +50,7 @@
   <script src="widget/storage-file.js"></script>
   <script src="widget/storage-folder.js"></script>
   <script src="widget/non-storage.js"></script>
+  <script src="widget/local-storage-file.js"></script>
   <script src="widget/main.js"></script>
   <script src="widget/analytics.js"></script>
   <!-- endbuild -->

--- a/src/widget/image.js
+++ b/src/widget/image.js
@@ -83,7 +83,7 @@ RiseVision.Image = ( function( gadgets ) {
 
   function _testLocalStorage() {
     // don't test if display id is invalid or preview/local
-    if ( !_displayId || _displayId === "preview" || _displayId === "display_id" || _displayId.indexOf("displayId") !== -1 ) {
+    if ( !_displayId || _displayId === "preview" || _displayId === "display_id" || _displayId.indexOf( "displayId" ) !== -1 ) {
       return;
     }
 

--- a/src/widget/image.js
+++ b/src/widget/image.js
@@ -14,6 +14,7 @@ RiseVision.Image = ( function( gadgets ) {
     _params = null,
     _storage = null,
     _nonStorage = null,
+    _localStorage = null,
     _slider = null,
     _currentFiles = [],
     _errorLog = null,
@@ -80,6 +81,16 @@ RiseVision.Image = ( function( gadgets ) {
     return null;
   }
 
+  function _testLocalStorage() {
+    // don't test if display id is invalid or preview/local
+    if ( !_displayId || _displayId === "preview" || _displayId === "display_id" || _displayId.indexOf("displayId") !== -1 ) {
+      return;
+    }
+
+    _localStorage = new RiseVision.Image.LocalStorageFile();
+    _localStorage.init();
+  }
+
   function init() {
     var container = document.getElementById( "container" ),
       fragment = document.createDocumentFragment(),
@@ -134,6 +145,7 @@ RiseVision.Image = ( function( gadgets ) {
       _storage.init();
     }
 
+    _testLocalStorage();
     _ready();
   }
 

--- a/src/widget/local-storage-file.js
+++ b/src/widget/local-storage-file.js
@@ -8,7 +8,7 @@ RiseVision.Image.LocalStorageFile = function() {
   var wsClient = RiseVision.Common.WSClient,
     testGCSImage = "local-storage-test/test-1x1.png",
     watchMessageAlreadySent = false,
-    testImageDownloadAttempted = false;
+    testImageLoadAttempted = false;
 
   function _clientListHandler( message ) {
     var clients = message.clients;
@@ -53,31 +53,31 @@ RiseVision.Image.LocalStorageFile = function() {
     } );
 
     // test downloading the image
-    if ( !testImageDownloadAttempted && message.status && message.status === "CURRENT" ) {
+    if ( !testImageLoadAttempted && message.status && message.status === "CURRENT" ) {
       imgTest = new Image();
 
       imgTest.onload = function() {
         RiseVision.Image.logEvent( {
-          "event": "Test image downloaded",
+          "event": "Test image loaded",
           "file_url": message.ospath
         } );
       };
 
       imgTest.onerror = function( err ) {
         RiseVision.Image.logEvent( {
-          "event": "Test image download failed",
+          "event": "Test image load failed",
           "event_details": JSON.stringify( err ),
           "file_url": message.ospath
         } );
       };
 
       RiseVision.Image.logEvent( {
-        "event": "Attempt test image download",
+        "event": "Attempt test image load",
         "file_url": message.ospath
       } );
 
       imgTest.src = "file://" + message.ospath;
-      testImageDownloadAttempted = true;
+      testImageLoadAttempted = true;
     }
   }
 

--- a/src/widget/local-storage-file.js
+++ b/src/widget/local-storage-file.js
@@ -100,6 +100,8 @@ RiseVision.Image.LocalStorageFile = function() {
           return _fileErrorHandler( message );
         }
       } );
+
+      wsClient.getModuleClientList();
     }
   }
 

--- a/src/widget/local-storage-file.js
+++ b/src/widget/local-storage-file.js
@@ -6,7 +6,7 @@ RiseVision.Image.LocalStorageFile = function() {
   "use strict";
 
   var wsClient = RiseVision.Common.WSClient,
-    testGCSImage = "https://storage.googleapis.com/local-storage-test/test-1x1.png",
+    testGCSImage = "local-storage-test/test-1x1.png",
     watchMessageAlreadySent = false,
     testImageDownloaded = false;
 
@@ -49,22 +49,22 @@ RiseVision.Image.LocalStorageFile = function() {
     } );
 
     // test downloading the image
-    if ( !testImageDownloaded ) {
+    if ( !testImageDownloaded && message.ospath ) {
       imgTest.onload = function() {
         RiseVision.Image.logEvent( {
           "event": "Test image downloaded",
-          "file_url": message.filePath
+          "file_url": message.ospath
         } );
       };
 
       imgTest.onerror = function() {
         RiseVision.Image.logEvent( {
           "event": "Test image download failed",
-          "file_url": message.filePath
+          "file_url": message.ospath
         } );
       };
 
-      imgTest.src = message.filePath;
+      imgTest.src = message.ospath;
       testImageDownloaded = true;
     }
   }

--- a/src/widget/local-storage-file.js
+++ b/src/widget/local-storage-file.js
@@ -8,7 +8,7 @@ RiseVision.Image.LocalStorageFile = function() {
   var wsClient = RiseVision.Common.WSClient,
     testGCSImage = "local-storage-test/test-1x1.png",
     watchMessageAlreadySent = false,
-    testImageDownloaded = false;
+    testImageDownloadAttempted = false;
 
   function _clientListHandler( message ) {
     var clients = message.clients;
@@ -41,6 +41,10 @@ RiseVision.Image.LocalStorageFile = function() {
   function _fileUpdateHandler( message ) {
     var imgTest = null;
 
+    if ( !message.filePath || message.filePath !== testGCSImage ) {
+      return;
+    }
+
     // log successful test of receiving FILE-UPDATE message
     RiseVision.Image.logEvent( {
       "event": "Test image FILE-UPDATE",
@@ -49,7 +53,7 @@ RiseVision.Image.LocalStorageFile = function() {
     } );
 
     // test downloading the image
-    if ( !testImageDownloaded && message.ospath ) {
+    if ( !testImageDownloadAttempted && message.status && message.status === "CURRENT" ) {
       imgTest.onload = function() {
         RiseVision.Image.logEvent( {
           "event": "Test image downloaded",
@@ -64,8 +68,13 @@ RiseVision.Image.LocalStorageFile = function() {
         } );
       };
 
+      RiseVision.Image.logEvent( {
+        "event": "Attempt test image download",
+        "file_url": message.ospath
+      } );
+
       imgTest.src = message.ospath;
-      testImageDownloaded = true;
+      testImageDownloadAttempted = true;
     }
   }
 

--- a/src/widget/local-storage-file.js
+++ b/src/widget/local-storage-file.js
@@ -1,0 +1,109 @@
+var RiseVision = RiseVision || {};
+
+RiseVision.Image = RiseVision.Image || {};
+
+RiseVision.Image.LocalStorageFile = function() {
+  "use strict";
+
+  var wsClient = RiseVision.Common.WSClient,
+    testGCSImage = "https://storage.googleapis.com/local-storage-test/test-1x1.png",
+    watchMessageAlreadySent = false,
+    testImageDownloaded = false;
+
+  function _clientListHandler( message ) {
+    var clients = message.clients;
+
+    if ( !watchMessageAlreadySent ) {
+      if ( clients.includes( "local-storage" ) ) {
+        // log that LS is present
+        RiseVision.Image.logEvent( {
+          "event": "LS is present",
+          "file_url": testGCSImage
+        } );
+
+        // send test WATCH for test image file on GCS bucket configured with Pub/Sub
+        wsClient.broadcastMessage( {
+          "topic": "WATCH",
+          "filePath": testGCSImage
+        } );
+
+        watchMessageAlreadySent = true;
+      } else {
+        // log that LS is not present (yet)
+        RiseVision.Image.logEvent( {
+          "event": "LS is not present",
+          "file_url": testGCSImage
+        } );
+      }
+    }
+  }
+
+  function _fileUpdateHandler( message ) {
+    var imgTest = null;
+
+    // log successful test of receiving FILE-UPDATE message
+    RiseVision.Image.logEvent( {
+      "event": "Test image FILE-UPDATE",
+      "event_details": JSON.stringify( message ),
+      "file_url": message.filePath
+    } );
+
+    // test downloading the image
+    if ( !testImageDownloaded ) {
+      imgTest.onload = function() {
+        RiseVision.Image.logEvent( {
+          "event": "Test image downloaded",
+          "file_url": message.filePath
+        } );
+      };
+
+      imgTest.onerror = function() {
+        RiseVision.Image.logEvent( {
+          "event": "Test image download failed",
+          "file_url": message.filePath
+        } );
+      };
+
+      imgTest.src = message.filePath;
+      testImageDownloaded = true;
+    }
+  }
+
+  function _fileErrorHandler( message ) {
+    RiseVision.Image.logEvent( {
+      "event": "Test image FILE-ERROR",
+      "event_details": JSON.stringify( message ),
+      "file_url": message.filePath
+    } );
+  }
+
+  function init() {
+    if ( wsClient.canConnect() ) {
+
+      wsClient.receiveMessages( function( message ) {
+        if ( !message || !message.topic ) {
+          RiseVision.Image.logEvent( {
+            "event": "Invalid LMS message received",
+            "event_details": JSON.stringify( message ),
+            "file_url": testGCSImage
+          } );
+
+          return;
+        }
+
+        switch ( message.topic.toUpperCase() ) {
+        case "CLIENT-LIST":
+          return _clientListHandler( message );
+        case "FILE-UPDATE":
+          return _fileUpdateHandler( message );
+        case "FILE-ERROR":
+          return _fileErrorHandler( message );
+        }
+      } );
+    }
+  }
+
+  return {
+    "init": init
+  };
+};

--- a/src/widget/local-storage-file.js
+++ b/src/widget/local-storage-file.js
@@ -54,6 +54,8 @@ RiseVision.Image.LocalStorageFile = function() {
 
     // test downloading the image
     if ( !testImageDownloadAttempted && message.status && message.status === "CURRENT" ) {
+      imgTest = new Image();
+
       imgTest.onload = function() {
         RiseVision.Image.logEvent( {
           "event": "Test image downloaded",
@@ -61,9 +63,10 @@ RiseVision.Image.LocalStorageFile = function() {
         } );
       };
 
-      imgTest.onerror = function() {
+      imgTest.onerror = function( err ) {
         RiseVision.Image.logEvent( {
           "event": "Test image download failed",
+          "event_details": JSON.stringify( err ),
           "file_url": message.ospath
         } );
       };
@@ -73,7 +76,7 @@ RiseVision.Image.LocalStorageFile = function() {
         "file_url": message.ospath
       } );
 
-      imgTest.src = message.ospath;
+      imgTest.src = "file://" + message.ospath;
       testImageDownloadAttempted = true;
     }
   }


### PR DESCRIPTION
Facilitating a test of using Local Storage by sending WATCH on test GCS file that resides in bucket configured for Pub/Sub notifications. Also handles FILE-UPDATE and FILE-ERROR.

Details on validating [here](https://trello.com/c/ouwoIFeT/3747-3-widget-sends-watch-and-logs-for-unsuccessful-file-update-from-local-storage)