### PR TITLE
updates growl to fix known vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3357,6 +3357,26 @@
       "integrity": "sha1-HQGuyvbPGRGAyKc6tACVw2dEI9w=",
       "dev": true
     },
+    "eslint-plugin-node": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
+      "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
+      "dev": true,
+      "requires": {
+        "ignore": "3.3.7",
+        "minimatch": "3.0.4",
+        "resolve": "1.6.0",
+        "semver": "5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
     "espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
@@ -5694,10 +5714,13 @@
       "dev": true
     },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-      "dev": true
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.2.tgz",
+      "integrity": "sha512-nidsnaoWVZIBLwA3sUIp3dA2DP2rT3dwEqINVacQ0+rZmc6UOwj2D729HTEjQYUKb+3wL9MeDbxpZtEiEJoUHQ==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-node": "5.2.1"
+      }
     },
     "gulp": {
       "version": "3.8.11",
@@ -9456,7 +9479,6 @@
         "diff": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
-        "growl": "1.9.2",
         "he": "1.1.1",
         "json3": "3.3.2",
         "lodash.create": "3.1.1",
@@ -9691,6 +9713,12 @@
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
       "dev": true,
       "optional": true
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+      "dev": true
     },
     "nodegit-promise": {
       "version": "4.0.0",
@@ -13564,6 +13592,12 @@
             "once": "1.4.0"
           }
         },
+        "growl": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+          "dev": true
+        },
         "lodash": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
@@ -13638,12 +13672,6 @@
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
           "dev": true
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "del": "~1.1.1",
     "eslint": "^3.8.1",
     "eslint-config-idiomatic": "^2.1.0",
+    "growl": "1.10.2",
     "gulp": "~3.8.3",
     "gulp-babel": "^7.0.1",
     "gulp-bower": "~0.0.10",


### PR DESCRIPTION
@jungeunyoon @Rise-Vision/content please review - this updates the growl dependency to 1.10.2 to fix the security vulnerability. Thanks!