### PR TITLE
updates growl to 1.10.5 to fix known vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3357,26 +3357,6 @@
       "integrity": "sha1-HQGuyvbPGRGAyKc6tACVw2dEI9w=",
       "dev": true
     },
-    "eslint-plugin-node": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
-      "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
-      "dev": true,
-      "requires": {
-        "ignore": "3.3.7",
-        "minimatch": "3.0.4",
-        "resolve": "1.6.0",
-        "semver": "5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        }
-      }
-    },
     "espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
@@ -5714,13 +5694,10 @@
       "dev": true
     },
     "growl": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.2.tgz",
-      "integrity": "sha512-nidsnaoWVZIBLwA3sUIp3dA2DP2rT3dwEqINVacQ0+rZmc6UOwj2D729HTEjQYUKb+3wL9MeDbxpZtEiEJoUHQ==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-node": "5.2.1"
-      }
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
     },
     "gulp": {
       "version": "3.8.11",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "del": "~1.1.1",
     "eslint": "^3.8.1",
     "eslint-config-idiomatic": "^2.1.0",
-    "growl": "1.10.2",
+    "growl": "1.10.5",
     "gulp": "~3.8.3",
     "gulp-babel": "^7.0.1",
     "gulp-bower": "~0.0.10",


### PR DESCRIPTION
@Rise-Vision/content please review - updating growl to 1.10.2 didn't remove the warning so now updating to 1.10.5. Thanks!