### PR TITLE
Support getting Storage licensing authorization without Licensing module

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,7 +35,8 @@
     ],
     es6Modules = [
       "./node_modules/common-component/local-messaging.js",
-      "./node_modules/common-component/player-local-storage.js"
+      "./node_modules/common-component/player-local-storage.js",
+      "./node_modules/common-component/player-local-storage-licensing.js"
     ];
 
   gulp.task("clean", function (cb) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2270,7 +2270,7 @@
       "optional": true
     },
     "common-component": {
-      "version": "git://github.com/Rise-Vision/common-component.git#37204ad58fa9a9c15245f852ad21c1b8a6a66dc8",
+      "version": "git://github.com/Rise-Vision/common-component.git#114f0abf22fdf658fc1e3fe48a01e426bdc2f24f",
       "dev": true
     },
     "component-bind": {
@@ -9456,6 +9456,7 @@
         "diff": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
+        "growl": "1.9.2",
         "he": "1.1.1",
         "json3": "3.3.2",
         "lodash.create": "3.1.1",
@@ -9494,6 +9495,12 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "growl": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+          "dev": true
         },
         "minimist": {
           "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bower": "^1.5.3",
     "chai": "^2.1.2",
     "chai-as-promised": "^4.3.0",
-    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.12.3",
+    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.14.0",
     "del": "~1.1.1",
     "eslint": "^3.8.1",
     "eslint-config-idiomatic": "^2.1.0",

--- a/src/widget.html
+++ b/src/widget.html
@@ -53,6 +53,7 @@
   <script src="components/widget-common/dist/rise-cache.js"></script>
   <script src="common-modules/local-messaging.js"></script>
   <script src="common-modules/player-local-storage.js"></script>
+  <script src="common-modules/player-local-storage-licensing.js"></script>
   <script src="config/version.js"></script>
   <script src="config/config.js"></script>
   <script src="widget/image-utils.js"></script>

--- a/src/widget/image-rls.js
+++ b/src/widget/image-rls.js
@@ -141,7 +141,7 @@ RiseVision.ImageRLS = ( function( gadgets ) {
     _imageUtils.sendDoneToViewer();
   }
 
-  function setAdditionalParams( additionalParams, modeType ) {
+  function setAdditionalParams( additionalParams, modeType, companyId ) {
     var data = _.clone( additionalParams );
 
     _imageUtils.setMode( modeType );
@@ -149,6 +149,7 @@ RiseVision.ImageRLS = ( function( gadgets ) {
 
     data.width = _prefs.getInt( "rsW" );
     data.height = _prefs.getInt( "rsH" );
+    data.companyId = companyId;
 
     _imageUtils.setParams( data );
 

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -88,7 +88,7 @@
 
         if ( useRLS ) {
           // proceed with using RLS for single file
-          RiseVision.ImageRLS.setAdditionalParams( additionalParams, mode, displayId );
+          RiseVision.ImageRLS.setAdditionalParams( additionalParams, mode, companyId );
           return;
         }
 

--- a/test/integration/js/player-local-storage-stubs.js
+++ b/test/integration/js/player-local-storage-stubs.js
@@ -22,12 +22,13 @@ top.RiseVision.Viewer.LocalMessaging = {
   }
 };
 
-sinon.stub( RiseVision.ImageRLS, "setAdditionalParams", function( params, mode, displayId ) {
+sinon.stub( RiseVision.ImageRLS, "setAdditionalParams", function( params, mode ) {
   ready = true; // eslint-disable-line no-undef
 
   // spy on log call
   logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" ); // eslint-disable-line no-undef
 
   RiseVision.ImageRLS.setAdditionalParams.restore();
-  RiseVision.ImageRLS.setAdditionalParams( params, mode, displayId );
+  // override company id to be the same company from the test data to bypass making direct licensing authorization request
+  RiseVision.ImageRLS.setAdditionalParams( params, mode, "30007b45-3df0-4c7b-9f7f-7d8ce6443013" );
 } );

--- a/test/integration/player-local-storage/file.html
+++ b/test/integration/player-local-storage/file.html
@@ -24,6 +24,7 @@
 <script src="../../../src/components/widget-common/dist/common.js"></script>
 <script src="../../../src/common-modules/local-messaging.js"></script>
 <script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/image-utils.js"></script>

--- a/test/integration/player-local-storage/folder-one-file.html
+++ b/test/integration/player-local-storage/folder-one-file.html
@@ -28,6 +28,7 @@
 <script src="../../../src/components/widget-common/dist/common.js"></script>
 <script src="../../../src/common-modules/local-messaging.js"></script>
 <script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/image-utils.js"></script>

--- a/test/integration/player-local-storage/folder.html
+++ b/test/integration/player-local-storage/folder.html
@@ -28,6 +28,7 @@
 <script src="../../../src/components/widget-common/dist/common.js"></script>
 <script src="../../../src/common-modules/local-messaging.js"></script>
 <script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/image-utils.js"></script>

--- a/test/integration/player-local-storage/logging-file.html
+++ b/test/integration/player-local-storage/logging-file.html
@@ -24,6 +24,7 @@
 <script src="../../../src/components/widget-common/dist/common.js"></script>
 <script src="../../../src/common-modules/local-messaging.js"></script>
 <script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/image-utils.js"></script>

--- a/test/integration/player-local-storage/logging-folder.html
+++ b/test/integration/player-local-storage/logging-folder.html
@@ -28,6 +28,7 @@
 <script src="../../../src/components/widget-common/dist/common.js"></script>
 <script src="../../../src/common-modules/local-messaging.js"></script>
 <script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/image-utils.js"></script>

--- a/test/integration/player-local-storage/messaging-file.html
+++ b/test/integration/player-local-storage/messaging-file.html
@@ -24,6 +24,7 @@
 <script src="../../../src/components/widget-common/dist/common.js"></script>
 <script src="../../../src/common-modules/local-messaging.js"></script>
 <script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/image-utils.js"></script>

--- a/test/integration/player-local-storage/messaging-folder.html
+++ b/test/integration/player-local-storage/messaging-folder.html
@@ -24,6 +24,7 @@
 <script src="../../../src/components/widget-common/dist/common.js"></script>
 <script src="../../../src/common-modules/local-messaging.js"></script>
 <script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
 <script src="../../../src/config/version.js"></script>
 <script src="../../../src/config/test.js"></script>
 <script src="../../../src/widget/image-utils.js"></script>


### PR DESCRIPTION
- Adds instantiation of common licensing library
- Compares company id provided by gadgets rpc call with the company id provided in the widget settings data that is associated with the storage file (or folder) and provides to the licensing instantiation. 
- If company ids are the same, licensing module will be used for authorization
- Licensing common library handles making direct request to Store API if company ids are different and the company id associated with file is not white listed. 
- Widget logs if there is an authorization failure when a direct request has been made
