### PR TITLE
Add log value for new "configuration" field [stage-2]

### DIFF
--- a/src/widget/image-utils.js
+++ b/src/widget/image-utils.js
@@ -120,6 +120,7 @@ RiseVision.ImageUtils = ( function() {
   }
 
   function logEvent( data ) {
+    data.configuration = getConfigurationType();
     RiseVision.Common.LoggerUtils.logEvent( getTableName(), data );
   }
 

--- a/src/widget/image-utils.js
+++ b/src/widget/image-utils.js
@@ -120,7 +120,7 @@ RiseVision.ImageUtils = ( function() {
   }
 
   function logEvent( data ) {
-    data.configuration = getConfigurationType();
+    data.configuration = getConfigurationType() || "";
     RiseVision.Common.LoggerUtils.logEvent( getTableName(), data );
   }
 

--- a/test/integration/image-utils.html
+++ b/test/integration/image-utils.html
@@ -134,6 +134,7 @@
           "event_details": "image load error",
           "file_url": "test-bucket/widget-testing/image-widget/Gone_Girl_Book_Cover.jpg",
           "file_format": "jpg",
+          "configuration": "",
           "company_id": "",
           "display_id": ""
         },

--- a/test/integration/js/player-local-storage-logging-file.js
+++ b/test/integration/js/player-local-storage-logging-file.js
@@ -9,6 +9,7 @@ var table = "image_events",
     "event_details": "",
     "file_url": "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/Gone_Girl_Book_Cover.jpg",
     "file_format": "jpg",
+    "configuration": "storage file (rls)",
     "company_id": "\"companyId\"",
     "display_id": "\"displayId\"",
     "version": "0.1.1"
@@ -41,9 +42,10 @@ suite( "configuration", function() {
 
     assert( logSpy.calledWith( table, {
       "event": "configuration",
-      "event_details": "storage file (rls)",
+      "event_details": params.configuration,
       "file_url": params.file_url,
       "file_format": params.file_format,
+      "configuration": params.configuration,
       "company_id": params.company_id,
       "display_id": params.display_id,
       "version": params.version

--- a/test/integration/js/player-local-storage-logging-folder.js
+++ b/test/integration/js/player-local-storage-logging-folder.js
@@ -9,6 +9,7 @@ var table = "image_events",
     "event_details": "",
     "file_url": "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/",
     "file_format": "unknown",
+    "configuration": "storage folder (rls)",
     "company_id": "\"companyId\"",
     "display_id": "\"displayId\"",
     "version": "0.1.1"
@@ -48,9 +49,10 @@ suite( "configuration", function() {
 
     assert( logSpy.calledWith( table, {
       "event": "configuration",
-      "event_details": "storage folder (rls)",
+      "event_details": params.configuration,
       "file_url": params.file_url,
       "file_format": "JPG|JPEG|PNG|BMP|SVG|GIF|WEBP",
+      "configuration": params.configuration,
       "company_id": params.company_id,
       "display_id": params.display_id,
       "version": params.version
@@ -335,6 +337,7 @@ suite( "folder file deleted", function() {
       event_details: "No files to display",
       file_url: params.file_url,
       file_format: "unknown",
+      configuration: params.configuration,
       company_id: params.company_id,
       display_id: params.display_id,
       version: params.version

--- a/test/integration/js/storage-logging-file.js
+++ b/test/integration/js/storage-logging-file.js
@@ -9,6 +9,7 @@ var table = "image_events",
     "error_details": "The request failed with status code: 404",
     "file_url": "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443%2FWidgets%2Fsimpson's.jpg",
     "file_format": "jpg",
+    "configuration": "storage file",
     "company_id": "\"companyId\"",
     "display_id": "\"displayId\"",
     "version": "0.1.1"
@@ -51,9 +52,10 @@ suite( "configuration", function() {
 
     assert( spy.calledWith( table, {
       "event": "configuration",
-      "event_details": "storage file",
+      "event_details": params.configuration,
       "file_url": "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/Gone_Girl_Book_Cover.jpg",
       "file_format": "jpg",
+      "configuration": params.configuration,
       "company_id": params.company_id,
       "display_id": params.display_id,
       "version": params.version

--- a/test/integration/js/storage-logging-folder.js
+++ b/test/integration/js/storage-logging-folder.js
@@ -7,6 +7,7 @@ var table = "image_events",
   params = {
     "event": "error",
     "event_details": "storage folder empty",
+    "configuration": "storage folder",
     "company_id": "\"companyId\"",
     "display_id": "\"displayId\"",
     "version": "0.1.1"
@@ -70,9 +71,10 @@ suite( "configuration", function() {
 
     assert( spy.calledWith( table, {
       "event": "configuration",
-      "event_details": "storage folder",
+      "event_details": params.configuration,
       "file_url": "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/",
       "file_format": "JPG|JPEG|PNG|BMP|SVG|GIF|WEBP",
+      "configuration": params.configuration,
       "company_id": params.company_id,
       "display_id": params.display_id,
       "version": params.version

--- a/test/integration/non-storage/logging.html
+++ b/test/integration/non-storage/logging.html
@@ -44,6 +44,7 @@
         "event": "play",
         "file_url": "http://s3.amazonaws.com/rise-common/images/logo-small.png",
         "file_format": "png",
+        "configuration": "custom",
         "company_id": '"companyId"',
         "display_id": '"displayId"',
         "version": "0.1.1"
@@ -125,9 +126,10 @@
 
         assert(spy.calledWith(table, {
           "event": "configuration",
-          "event_details": "custom",
+          "event_details": params.configuration,
           "file_url": params.file_url,
           "file_format": params.file_format,
+          "configuration": params.configuration,
           "company_id": params.company_id,
           "display_id": params.display_id,
           "version": params.version

--- a/test/unit/image-utils-spec.js
+++ b/test/unit/image-utils-spec.js
@@ -27,6 +27,7 @@ describe( "logEvent", function() {
       "event_details": "test details",
       "file_url": "http://www.test.com/file.jpg",
       "file_format": "jpg",
+      "configuration": "",
       "company_id": "",
       "display_id": ""
     };
@@ -43,6 +44,7 @@ describe( "logEvent", function() {
   it( "should call spy with correct parameters when only the event is set", function() {
     var params = {
       "event": "test",
+      "configuration": "",
       "company_id": "",
       "display_id": ""
     };


### PR DESCRIPTION
- We need to differentiate "error" logs by configuration, this allows us to do so
- `image_events` table has had a _configuration_ field added