### PR TITLE
Fix getStorageFileName() util function to account for # or ? in file name

### DIFF
--- a/src/widget/image-utils.js
+++ b/src/widget/image-utils.js
@@ -32,7 +32,7 @@ RiseVision.ImageUtils = ( function() {
       return "";
     }
 
-    return filePath.split( "#" ).shift().split( "?" ).shift().split( "/" ).pop();
+    return filePath.split( "risemedialibrary-" ).pop().split( "/" ).pop();
   }
 
   function getStorageSingleFilePath() {

--- a/test/unit/image-utils-spec.js
+++ b/test/unit/image-utils-spec.js
@@ -10,6 +10,30 @@ describe( "getTableName", function() {
   } );
 } );
 
+describe( "getStorageFileName", function() {
+  it( "should provide file name from storage file path (bucket only)", function() {
+    expect( RiseVision.ImageUtils.getStorageFileName( "risemedialibrary-abc123/test-file.jpg" ) ).to.equal( "test-file.jpg" );
+  } );
+
+  it( "should provide file name from storage file path (with subfolder)", function() {
+    expect( RiseVision.ImageUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/test-file.jpg" ) ).to.equal( "test-file.jpg" );
+  } );
+
+  it( "should provide file name from storage file path (bucket only) when name has special characters", function() {
+    expect( RiseVision.ImageUtils.getStorageFileName( "risemedialibrary-abc123/([!@?,#$])=1+2-A | <>.jpg" ) ).to.equal( "([!@?,#$])=1+2-A | <>.jpg" );
+    expect( RiseVision.ImageUtils.getStorageFileName( "risemedialibrary-abc123/test %.jpg" ) ).to.equal( "test %.jpg" );
+    expect( RiseVision.ImageUtils.getStorageFileName( "risemedialibrary-abc123/test *.jpg" ) ).to.equal( "test *.jpg" );
+    expect( RiseVision.ImageUtils.getStorageFileName( "risemedialibrary-abc123/test Ü.jpg" ) ).to.equal( "test Ü.jpg" );
+  } );
+
+  it( "should provide file name from storage file path (with subfolder) when name has special characters", function() {
+    expect( RiseVision.ImageUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/([!@?,#$])=1+2-A | <>.jpg" ) ).to.equal( "([!@?,#$])=1+2-A | <>.jpg" );
+    expect( RiseVision.ImageUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/test %.jpg" ) ).to.equal( "test %.jpg" );
+    expect( RiseVision.ImageUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/test *.jpg" ) ).to.equal( "test *.jpg" );
+    expect( RiseVision.ImageUtils.getStorageFileName( "risemedialibrary-abc123/test-folder/nested-folder/test Ü.jpg" ) ).to.equal( "test Ü.jpg" );
+  } );
+} );
+
 describe( "logEvent", function() {
   var logSpy;
 


### PR DESCRIPTION
Presentation validated on my display YSD5WEDW339F - https://apps.risevision.com/editor/workspace/dce2352c-c43f-4bf0-a219-6e2c94f9d3f1/?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013