### PR TITLE
Handling SVGs for RLS single and folder configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "gulpfile.js",
   "scripts": {
     "test": "gulp test",
-    "build": "gulp build && ./include-deps.sh"
+    "build": "gulp build && ./include-deps.sh",
+    "build-dev": "gulp build-dev && ./include-deps.sh"
   },
   "repository": {
     "type": "git",

--- a/src/widget/image-rls.js
+++ b/src/widget/image-rls.js
@@ -91,6 +91,18 @@ RiseVision.ImageRLS = ( function( gadgets ) {
   }
 
   function setSingleImage( url ) {
+    var filePath = _imageUtils.getStorageSingleFilePath();
+
+    if ( _imageUtils.isSVGImage( filePath ) ) {
+      _imageUtils.convertSVGToDataURL( filePath, url, function( dataUrl ) {
+        if ( dataUrl ) {
+          _imageUtils.handleSingleImageLoad( dataUrl, _viewerPaused );
+        }
+      } );
+
+      return;
+    }
+
     _img.onload = function() {
       _imageUtils.handleSingleImageLoad( url, _viewerPaused );
     };

--- a/src/widget/image-utils.js
+++ b/src/widget/image-utils.js
@@ -175,7 +175,11 @@ RiseVision.ImageUtils = ( function() {
   }
 
   function isSVGImage( filePath ) {
-    return filePath.toLowerCase().indexOf( ".svg" ) > 0;
+    if ( !filePath || typeof filePath !== "string" ) {
+      return false;
+    }
+
+    return filePath.toLowerCase().split( "." ).pop().split( /\#|\?/ )[ 0 ] === "svg";
   }
 
   function isUsingRLS() {

--- a/src/widget/image-utils.js
+++ b/src/widget/image-utils.js
@@ -178,6 +178,10 @@ RiseVision.ImageUtils = ( function() {
     return filePath.toLowerCase().indexOf( ".svg" ) > 0;
   }
 
+  function isUsingRLS() {
+    return _usingRLS;
+  }
+
   function logEvent( data ) {
     data.configuration = getConfigurationType() || "";
     RiseVision.Common.LoggerUtils.logEvent( getTableName(), data );
@@ -219,6 +223,7 @@ RiseVision.ImageUtils = ( function() {
     "handleSingleImageLoadError": handleSingleImageLoadError,
     "isSingleImageGIF": isSingleImageGIF,
     "isSVGImage": isSVGImage,
+    "isUsingRLS": isUsingRLS,
     "getImageElement": getImageElement,
     "getStorageFileName": getStorageFileName,
     "getStorageSingleFilePath": getStorageSingleFilePath,

--- a/src/widget/image-utils.js
+++ b/src/widget/image-utils.js
@@ -23,6 +23,61 @@ RiseVision.ImageUtils = ( function() {
     _errorTimer = null;
   }
 
+  function convertSVGToDataURL( filePath, localUrl, callback ) {
+    var xhr = new XMLHttpRequest();
+
+    function handleFailure( type ) {
+      logEvent( {
+        event: "error",
+        event_details: type,
+        file_url: filePath,
+        local_url: localUrl
+      } );
+
+      callback( null );
+    }
+
+    if ( !callback || typeof callback !== "function" ) {
+      return;
+    }
+
+    xhr.overrideMimeType( "image/svg+xml" );
+
+    xhr.onload = function() {
+      var reader = new FileReader();
+
+      reader.onloadend = function() {
+        if ( reader.error ) {
+          handleFailure( "svg read error" );
+          return;
+        }
+
+        logEvent( {
+          event: "info",
+          event_details: JSON.stringify( {
+            type: "svg file",
+            blob_size: xhr.response.size,
+            data_url_length: reader.result.length
+          } ),
+          file_url: filePath,
+          local_url: localUrl
+        } );
+
+        callback( reader.result );
+      };
+
+      reader.readAsDataURL( xhr.response );
+    };
+
+    xhr.onerror = function() {
+      handleFailure( "svg xhr error" );
+    };
+
+    xhr.open( "GET", localUrl );
+    xhr.responseType = "blob";
+    xhr.send();
+  }
+
   function getConfigurationType() {
     return _configurationType;
   }
@@ -119,6 +174,10 @@ RiseVision.ImageUtils = ( function() {
     return _isSingleImageGIF;
   }
 
+  function isSVGImage( filePath ) {
+    return filePath.toLowerCase().indexOf( ".svg" ) > 0;
+  }
+
   function logEvent( data ) {
     data.configuration = getConfigurationType() || "";
     RiseVision.Common.LoggerUtils.logEvent( getTableName(), data );
@@ -151,6 +210,7 @@ RiseVision.ImageUtils = ( function() {
 
   return {
     "clearErrorTimer": clearErrorTimer,
+    "convertSVGToDataURL": convertSVGToDataURL,
     "getConfigurationType": getConfigurationType,
     "getMode": getMode,
     "getParams": getParams,
@@ -158,6 +218,7 @@ RiseVision.ImageUtils = ( function() {
     "handleSingleImageLoad": handleSingleImageLoad,
     "handleSingleImageLoadError": handleSingleImageLoadError,
     "isSingleImageGIF": isSingleImageGIF,
+    "isSVGImage": isSVGImage,
     "getImageElement": getImageElement,
     "getStorageFileName": getStorageFileName,
     "getStorageSingleFilePath": getStorageSingleFilePath,

--- a/test/data/storage-file-svg.js
+++ b/test/data/storage-file-svg.js
@@ -1,0 +1,27 @@
+( function( window ) {
+  "use strict";
+
+  window.gadget = window.gadget || {};
+  window.gadget.settings = {
+    "params": {},
+    "additionalParams": {
+      "url": "",
+      "selector": {
+        "selection": "single-file",
+        "storageName": "widget-testing/image-widget/test-file.svg",
+        "url": "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing%2Fimage-widget%2Ftest-file.svg"
+      },
+      "storage": {
+        "folder": "widget-testing/image-widget/",
+        "fileName": "test-file.svg",
+        "companyId": "30007b45-3df0-4c7b-9f7f-7d8ce6443013"
+      },
+      "resume": true,
+      "scaleToFit": true,
+      "position": "top-left",
+      "duration": 1,
+      "pause": 10,
+      "autoHide": false
+    }
+  };
+} )( window );

--- a/test/index.html
+++ b/test/index.html
@@ -34,6 +34,7 @@
         "integration/storage-v2/messaging-folder.html",
         "integration/storage-v2/version.html",
         "integration/player-local-storage/file.html",
+        "integration/player-local-storage/file-svg.html",
         "integration/player-local-storage/folder.html",
         "integration/player-local-storage/folder-one-file.html",
         "integration/player-local-storage/logging-file.html",

--- a/test/integration/js/player-local-storage-file-svg.js
+++ b/test/integration/js/player-local-storage-file-svg.js
@@ -1,0 +1,128 @@
+/* global suiteSetup, suite, setup, teardown, test, assert, suiteTeardown,
+ RiseVision, sinon */
+
+/* eslint-disable func-names */
+
+var messageHandlers;
+
+suite( "file added", function() {
+  var onFileInitSpy,
+    handleImageSpy,
+    convertStub;
+
+  suiteSetup( function() {
+    onFileInitSpy = sinon.spy( RiseVision.ImageRLS, "onFileInit" );
+    handleImageSpy = sinon.spy( RiseVision.ImageUtils, "handleSingleImageLoad" );
+    convertStub = sinon.stub( RiseVision.ImageUtils, "convertSVGToDataURL", function( filePath, localUrl, callback ) {
+      callback( "data:image/svg+xml;base64,ABC123def456" );
+    } );
+
+    // mock receiving client-list message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "client-list",
+        clients: [ "local-storage", "licensing" ]
+      } );
+    } );
+
+    // mock receiving storage-licensing message
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "storage-licensing-update",
+        isAuthorized: true,
+        userFriendlyStatus: "authorized"
+      } );
+    } );
+
+    // mock receiving file-update to notify file is downloading
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/test-file.svg",
+        status: "STALE"
+      } );
+    } );
+
+    // mock receiving file-update to notify file is available
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/test-file.svg",
+        status: "CURRENT",
+        ospath: "path/to/file/abc123",
+        osurl: "file:///path/to/file/abc123"
+      } );
+    } );
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.ImageRLS.onFileInit.restore();
+    RiseVision.ImageUtils.handleSingleImageLoad.restore();
+    RiseVision.ImageUtils.convertSVGToDataURL.restore();
+  } );
+
+  test( "should set single image with a data url", function() {
+    assert( onFileInitSpy.calledOnce, "onFileInit() called once" );
+    assert( onFileInitSpy.calledWith( "file:///path/to/file/abc123" ), "onFileInit() called with correct url" );
+    assert.equal( convertStub.args[ 0 ][ 0 ], "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/test-file.svg" );
+    assert.equal( convertStub.args[ 0 ][ 1 ], "file:///path/to/file/abc123" );
+    assert.equal( handleImageSpy.args[ 0 ][ 0 ], "data:image/svg+xml;base64,ABC123def456" );
+
+  } );
+
+  test( "should align image at top left", function() {
+    assert.isNotNull( document.querySelector( ".top-left" ) );
+  } );
+
+  test( "should scale image to fit", function() {
+    assert.isNotNull( document.querySelector( ".scale-to-fit" ) );
+  } );
+} );
+
+suite( "file changed", function() {
+  var refreshSpy,
+    handleImageSpy,
+    convertStub;
+
+  setup( function() {
+    refreshSpy = sinon.spy( RiseVision.ImageRLS, "onFileRefresh" );
+    handleImageSpy = sinon.spy( RiseVision.ImageUtils, "handleSingleImageLoad" );
+    convertStub = sinon.stub( RiseVision.ImageUtils, "convertSVGToDataURL", function( filePath, localUrl, callback ) {
+      callback( "data:image/svg+xml;base64,ABC123def456" );
+    } );
+  } );
+
+  teardown( function() {
+    RiseVision.ImageRLS.onFileRefresh.restore();
+    RiseVision.ImageUtils.handleSingleImageLoad.restore();
+    RiseVision.ImageUtils.convertSVGToDataURL.restore();
+  } );
+
+  test( "should refresh single image with a data url", function() {
+    // mock receiving file-update to notify file is downloading
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/test-file.svg",
+        status: "STALE"
+      } );
+    } );
+
+    // mock receiving file-update to notify file is available
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "FILE-UPDATE",
+        filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/test-file.svg",
+        status: "CURRENT",
+        ospath: "path/to/file/def456",
+        osurl: "file:///path/to/file/def456"
+      } );
+    } );
+
+    assert( refreshSpy.calledOnce );
+    assert( refreshSpy.calledWith( "file:///path/to/file/def456" ), "onFileRefresh() called with correct url" );
+    assert.equal( convertStub.args[ 0 ][ 0 ], "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/test-file.svg" );
+    assert.equal( convertStub.args[ 0 ][ 1 ], "file:///path/to/file/def456" );
+    assert.equal( handleImageSpy.args[ 0 ][ 0 ], "data:image/svg+xml;base64,ABC123def456" );
+  } );
+} );

--- a/test/integration/player-local-storage/file-svg.html
+++ b/test/integration/player-local-storage/file-svg.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Image Widget</title>
+
+  <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
+  <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
+
+  <script src="../../../src/components/web-component-tester/browser.js"></script>
+</head>
+<body>
+
+<div id="container"></div>
+
+<div id="messageContainer"></div>
+
+<script src="../../../node_modules/widget-tester/mocks/gadget-mocks.js"></script>
+<script src="../../../node_modules/widget-tester/mocks/logger-mock.js"></script>
+
+<script src="../../../src/components/underscore/underscore.js"></script>
+<script src="../../../src/components/widget-common/dist/config.js"></script>
+<script src="../../../src/components/widget-common/dist/common.js"></script>
+<script src="../../../src/common-modules/local-messaging.js"></script>
+<script src="../../../src/common-modules/player-local-storage.js"></script>
+<script src="../../../src/common-modules/player-local-storage-licensing.js"></script>
+<script src="../../../src/config/version.js"></script>
+<script src="../../../src/config/test.js"></script>
+<script src="../../../src/widget/image-utils.js"></script>
+<script src="../../../src/widget/image-rls.js"></script>
+<script src="../../../src/widget/message.js"></script>
+<script src="../../../src/widget/player-local-storage-file.js"></script>
+
+<!-- TEST FILES -->
+<script src="../../data/storage-file-svg.js"></script>
+<script src="../js/player-local-storage-file-svg.js"></script>
+
+
+<script src="../js/player-local-storage-stubs.js"></script>
+<script src="../../../src/widget/main.js"></script>
+</body>
+</html>

--- a/test/unit/image-utils-spec.js
+++ b/test/unit/image-utils-spec.js
@@ -37,10 +37,14 @@ describe( "getStorageFileName", function() {
 describe( "isSVGImage", function() {
   it( "should return true when file path is for an SVG file", function() {
     expect( RiseVision.ImageUtils.isSVGImage( "risemedialibrary-abc123/test-folder/test-file.svg" ) ).to.be.true;
+    expect( RiseVision.ImageUtils.isSVGImage( "risemedialibrary-abc123/test-folder/test-file.png.svg" ) ).to.be.true;
+    expect( RiseVision.ImageUtils.isSVGImage( "risemedialibrary-abc123/test-folder/test-file.pngsource.svg" ) ).to.be.true;
   } );
 
   it( "should return false when file path is not for an SVG file", function() {
     expect( RiseVision.ImageUtils.isSVGImage( "risemedialibrary-abc123/test-folder/test-file.jpg" ) ).to.be.false;
+    expect( RiseVision.ImageUtils.isSVGImage( "risemedialibrary-abc123/test-folder/test-file.svg.jpg" ) ).to.be.false;
+    expect( RiseVision.ImageUtils.isSVGImage( "risemedialibrary-abc123/test-folder/test-file.svgsource.png" ) ).to.be.false;
   } );
 } );
 

--- a/test/unit/image-utils-spec.js
+++ b/test/unit/image-utils-spec.js
@@ -34,6 +34,16 @@ describe( "getStorageFileName", function() {
   } );
 } );
 
+describe( "isSVGImage", function() {
+  it( "should return true when file path is for an SVG file", function() {
+    expect( RiseVision.ImageUtils.isSVGImage( "risemedialibrary-abc123/test-folder/test-file.svg" ) ).to.be.true;
+  } );
+
+  it( "should return false when file path is not for an SVG file", function() {
+    expect( RiseVision.ImageUtils.isSVGImage( "risemedialibrary-abc123/test-folder/test-file.jpg" ) ).to.be.false;
+  } );
+} );
+
 describe( "logEvent", function() {
   var logSpy;
 


### PR DESCRIPTION
- Fix for issue #175 , also fixes Folder configuration which is also impacted (not mentioned in Issue)
- Using approach of converting the local file to a data url:
  - loading local file with `xhr` request as Blob response type with mime type forced to _"image/svg+xml"_
  - Use `FileReader` to read file as a data url
  - use data url as the value for url applied for `<div>` background image (single and folder implementations)
- In Folder configuration, ensuring to prep all urls that are provided to slider before slider is initialized with them by accounting for any SVG files and convert them to data urls
- Logging `info` event providing Blob size and data url length
- Folder integration tests not possible
- Validated with this presentation when running on a display - https://apps.risevision.com/editor/workspace/37c717d2-d7ec-4a6c-88a8-8ea51d1062f5/?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013