### PR TITLE
Fix/Fixes Issue #180

### DIFF
--- a/src/widget/image-rls.js
+++ b/src/widget/image-rls.js
@@ -160,6 +160,22 @@ RiseVision.ImageRLS = ( function( gadgets ) {
     }
   }
 
+  function onFileDeleted( message ) {
+    var image = document.querySelector( "#container #image" );
+
+    // clears image
+    _imageUtils.setSingleImageGIF( false );
+    image.style.backgroundImage = "none";
+    image.style.visibility = "hidden";
+
+    // displays message
+    _message.show( message );
+
+    if ( !_viewerPaused ) {
+      _imageUtils.sendDoneToViewer();
+    }
+  }
+
   function onSliderReady() {
     _message.hide();
 
@@ -249,6 +265,7 @@ RiseVision.ImageRLS = ( function( gadgets ) {
     "onFileInit": onFileInit,
     "onFileRefresh": onFileRefresh,
     "onFileUnavailable": onFileUnavailable,
+    "onFileDeleted": onFileDeleted,
     "onSliderComplete": onSliderComplete,
     "onSliderReady": onSliderReady,
     "pause": pause,

--- a/src/widget/image-rls.js
+++ b/src/widget/image-rls.js
@@ -166,7 +166,7 @@ RiseVision.ImageRLS = ( function( gadgets ) {
     // clears image
     _imageUtils.setSingleImageGIF( false );
     image.style.backgroundImage = "none";
-    image.style.visibility = "hidden";
+    image.style.visibility = "visible";
 
     // displays message
     _message.show( message );

--- a/src/widget/image-utils.js
+++ b/src/widget/image-utils.js
@@ -146,7 +146,7 @@ RiseVision.ImageUtils = ( function() {
     image.style.backgroundImage = "none";
     image.style.backgroundImage = "url('" + url + "')";
 
-    _isSingleImageGIF = url.indexOf( ".gif" ) !== -1;
+    setSingleImageGIF( url.indexOf( ".gif" ) !== -1 );
 
     // If widget is playing right now make sure the div image element is visible
     if ( !isViewerPaused && _isSingleImageGIF ) {
@@ -168,6 +168,10 @@ RiseVision.ImageUtils = ( function() {
     }
 
     logEvent( params );
+  }
+
+  function setSingleImageGIF( status ) {
+    _isSingleImageGIF = status;
   }
 
   function isSingleImageGIF() {
@@ -225,6 +229,7 @@ RiseVision.ImageUtils = ( function() {
     "startErrorTimer": startErrorTimer,
     "handleSingleImageLoad": handleSingleImageLoad,
     "handleSingleImageLoadError": handleSingleImageLoadError,
+    "setSingleImageGIF": setSingleImageGIF,
     "isSingleImageGIF": isSingleImageGIF,
     "isSVGImage": isSVGImage,
     "isUsingRLS": isUsingRLS,

--- a/src/widget/player-local-storage-file.js
+++ b/src/widget/player-local-storage-file.js
@@ -123,6 +123,8 @@ RiseVision.ImageRLS.PlayerLocalStorageFile = function() {
       "event": "file deleted",
       "file_url": data.filePath
     } );
+
+    RiseVision.ImageRLS.onFileDeleted( "The selected image has been moved to Trash." );
   }
 
   function _handleFileError( data ) {

--- a/test/integration/js/player-local-storage-file.js
+++ b/test/integration/js/player-local-storage-file.js
@@ -103,3 +103,28 @@ suite( "file changed", function() {
     assert( refreshSpy.calledWith( "file:///path/to/file/def456" ), "onFileRefresh() called with correct url" );
   } );
 } );
+
+suite( "file deleted", function() {
+  var onFileDeletedStub;
+
+  suiteSetup( function() {
+    onFileDeletedStub = sinon.stub( RiseVision.ImageRLS, "onFileDeleted" );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-update",
+        filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/widget-testing/image-widget/Gone_Girl_Book_Cover.jpg",
+        status: "deleted"
+      } );
+    } );
+
+  } );
+
+  suiteTeardown( function() {
+    RiseVision.ImageRLS.onFileDeleted.restore();
+  } );
+
+  test( "should display error and clear image", function() {
+    assert.equal( onFileDeletedStub.calledOnce, true );
+  } );
+} );

--- a/test/integration/js/player-local-storage-messaging-file.js
+++ b/test/integration/js/player-local-storage-messaging-file.js
@@ -201,7 +201,8 @@ suite( "file deleted", function() {
       } );
     } );
 
-    assert.isTrue( ( document.getElementById( "container" ).style.visibility === "visible" ), "image container is showing" );
-    assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "none" ), "message container is hidden" );
+    assert.isTrue( ( document.getElementById( "container" ).style.visibility === "hidden" ), "image container is hidden" );
+    assert.isFalse( ( document.getElementById( "messageContainer" ).style.display === "none" ), "message container is visibile" );
+    assert.equal( document.querySelector( ".message" ).innerHTML, "The selected image has been moved to Trash." );
   } );
 } );


### PR DESCRIPTION
- hides image and displays error message when file is deleted from storage
- verified on staging

@stulees Can you please verify that my logic is correct? When a user uploads a new image of the same name as the one in the trash right now it should just be stuck on the error message until Delivery makes changes on their part as part of [this card](https://trello.com/c/ZutE6CTU/4634-2-defect-757-storage-if-a-file-exists-in-trash-it-will-display-instead-of-a-file-with-the-same-path-and-filename-in-storage), correct? Because it's still watching the one in the trash. 