### PR TITLE
Clear slider variables on destroy and clone param ref [stage-2]

### DIFF
--- a/src/widget/image-rls.js
+++ b/src/widget/image-rls.js
@@ -1,5 +1,4 @@
 /* global gadgets, _ */
-/* eslint-disable no-console */
 
 var RiseVision = RiseVision || {};
 

--- a/src/widget/slider.js
+++ b/src/widget/slider.js
@@ -206,6 +206,12 @@ RiseVision.Slider = function( params, imageRef ) {
     // Let the slider clean up after itself.
     $api.revkill();
     $api = null;
+    totalSlides = 0;
+    isLastSlide = false;
+    refreshSlider = false;
+    isLoading = true;
+    isPlaying = false;
+    isInteracting = false;
   }
 
   // User has interacted with the slideshow.
@@ -326,7 +332,7 @@ RiseVision.Slider = function( params, imageRef ) {
       if ( $api ) {
         clearTimeout( singleImagePUDTimer );
         destroySlider();
-        init( files );
+        init( _.clone( files ) );
       }
     } else {
       newFiles = _.clone( files );


### PR DESCRIPTION
- When all files are removed the slider api instance was appropriately being destroyed, but  there were widget variables not being reset, particularly `refreshSlider` flag which was causing problems on future re-upload. Now ensuring to clear all relevant variables upon a destroy. 
- In a slider refresh when only 1 file is currently displayed, we were re-initializing with the param ref of file list instead of a cloned ref and this was causing a wrong initialization list when subsequent `refresh()` calls were being executed in quick succession. This has been fixed by ensuring to provide a cloned ref.  