### PR TITLE
Stop displaying error for folder NOEXIST and EMPTYFOLDER messages

### DIFF
--- a/src/widget/image-rls.js
+++ b/src/widget/image-rls.js
@@ -114,11 +114,17 @@ RiseVision.ImageRLS = ( function( gadgets ) {
     _img.src = url;
   }
 
+  function _resetFlags() {
+    _errorFlag = false;
+    _unavailableFlag = false;
+    _folderUnavailableFlag = false;
+  }
+
   /*
    *  Public Methods
    */
   function onFileInit( urls ) {
-    _unavailableFlag = false;
+    _resetFlags();
 
     if ( _imageUtils.getMode() === "file" ) {
       // remove message previously shown
@@ -151,9 +157,7 @@ RiseVision.ImageRLS = ( function( gadgets ) {
       }
     }
 
-    _errorFlag = false;
-    _unavailableFlag = false;
-    _folderUnavailableFlag = false;
+    _resetFlags();
   }
 
   function onFileUnavailable( message ) {

--- a/src/widget/image-rls.js
+++ b/src/widget/image-rls.js
@@ -16,6 +16,7 @@ RiseVision.ImageRLS = ( function( gadgets ) {
     _viewerPaused = true,
     _configurationLogged = false,
     _unavailableFlag = false,
+    _folderUnavailableFlag = false,
     _img = null;
 
   /*
@@ -152,6 +153,7 @@ RiseVision.ImageRLS = ( function( gadgets ) {
 
     _errorFlag = false;
     _unavailableFlag = false;
+    _folderUnavailableFlag = false;
   }
 
   function onFileUnavailable( message ) {
@@ -166,6 +168,17 @@ RiseVision.ImageRLS = ( function( gadgets ) {
     _imageUtils.handleSingleImageDeletion();
 
     showError( "The selected image has been moved to Trash." );
+  }
+
+  function onFolderUnavailable() {
+    _folderUnavailableFlag = true;
+
+    // set to a blank message so the image container gets hidden and nothing is displayed on screen
+    _message.show( "" );
+
+    if ( !_viewerPaused ) {
+      _imageUtils.sendDoneToViewer();
+    }
   }
 
   function onSliderReady() {
@@ -227,6 +240,12 @@ RiseVision.ImageRLS = ( function( gadgets ) {
       return;
     }
 
+    if ( _folderUnavailableFlag ) {
+      _imageUtils.sendDoneToViewer();
+
+      return;
+    }
+
     if ( _imageUtils.getMode() === "folder" && _slider && _slider.isReady() ) {
       _slider.play();
     } else if ( _imageUtils.getMode() === "file" && image && _imageUtils.isSingleImageGIF() ) {
@@ -258,6 +277,7 @@ RiseVision.ImageRLS = ( function( gadgets ) {
     "onFileRefresh": onFileRefresh,
     "onFileUnavailable": onFileUnavailable,
     "onFileDeleted": onFileDeleted,
+    "onFolderUnavailable": onFolderUnavailable,
     "onSliderComplete": onSliderComplete,
     "onSliderReady": onSliderReady,
     "pause": pause,

--- a/src/widget/player-local-storage-folder.js
+++ b/src/widget/player-local-storage-folder.js
@@ -245,7 +245,7 @@ RiseVision.ImageRLS.PlayerLocalStorageFolder = function() {
 
   function _handleFolderNoExist() {
     var params = {
-      "event": "error",
+      "event": "warning",
       "event_details": "folder does not exist",
       "file_url": folderPath,
       "file_format": defaultFileFormat

--- a/src/widget/player-local-storage-folder.js
+++ b/src/widget/player-local-storage-folder.js
@@ -1,5 +1,4 @@
 /* global localMessaging, playerLocalStorage, playerLocalStorageLicensing, config _ */
-/* eslint-disable no-console */
 
 var RiseVision = RiseVision || {};
 
@@ -108,7 +107,7 @@ RiseVision.ImageRLS.PlayerLocalStorageFolder = function() {
         "file_format": "unknown"
       } );
 
-      RiseVision.ImageRLS.showError( "Unable to display any files." );
+      RiseVision.ImageRLS.onFolderUnavailable();
     } else {
       RiseVision.ImageRLS.onFileRefresh( files );
     }
@@ -254,7 +253,7 @@ RiseVision.ImageRLS.PlayerLocalStorageFolder = function() {
 
     imageUtils.logEvent( params );
 
-    RiseVision.ImageRLS.showError( "The selected folder does not exist or has been moved to Trash." );
+    RiseVision.ImageRLS.onFolderUnavailable();
   }
 
   function _handleFolderEmpty() {
@@ -267,7 +266,7 @@ RiseVision.ImageRLS.PlayerLocalStorageFolder = function() {
 
     imageUtils.logEvent( params );
 
-    RiseVision.ImageRLS.showError( "The selected folder does not contain any images." );
+    RiseVision.ImageRLS.onFolderUnavailable();
   }
 
   function _handleFileDeleted( data ) {

--- a/test/integration/js/player-local-storage-logging-folder.js
+++ b/test/integration/js/player-local-storage-logging-folder.js
@@ -127,7 +127,9 @@ suite( "errors", function() {
 
   } );
 
-  test( "folder does not exist", function() {
+  test( "file error", function() {
+    var logParams;
+
     logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
 
     // mock receiving client-list message
@@ -149,27 +151,6 @@ suite( "errors", function() {
 
     messageHandlers.forEach( function( handler ) {
       handler( {
-        topic: "file-update",
-        filePath: params.file_url,
-        status: "NOEXIST"
-      } );
-    } );
-
-    params.event = "error";
-    params.event_details = "folder does not exist";
-
-    assert( logSpy.calledOnce );
-    assert( logSpy.calledWith( table, params ) );
-
-  } );
-
-  test( "file error", function() {
-    var logParams;
-
-    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
         topic: "file-error",
         filePath: params.file_url + "test-file-in-error.jpg",
         msg: "Could not retrieve signed URL",
@@ -180,6 +161,7 @@ suite( "errors", function() {
     logParams = JSON.parse( JSON.stringify( params ) );
     logParams.file_url = params.file_url + "test-file-in-error.jpg";
     logParams.file_format = "jpg";
+    logParams.event = "error";
     logParams.event_details = "Could not retrieve signed URL";
     logParams.error_details = "error details";
 
@@ -275,7 +257,7 @@ suite( "errors", function() {
       } );
     } );
 
-    logParams.event = params.event;
+    logParams.event = "error";
     logParams.file_url = params.file_url + "test-file-in-error-2.jpg";
     logParams.file_format = "jpg";
     logParams.event_details = "Could not retrieve signed URL";
@@ -347,6 +329,25 @@ suite( "folder file deleted", function() {
 } );
 
 suite( "folder is empty", function() {
+
+  test( "should log a warning when folder does not exist", function() {
+    logSpy = sinon.spy( RiseVision.Common.LoggerUtils, "logEvent" );
+
+    messageHandlers.forEach( function( handler ) {
+      handler( {
+        topic: "file-update",
+        filePath: params.file_url,
+        status: "NOEXIST"
+      } );
+    } );
+
+    params.event = "warning";
+    params.event_details = "folder does not exist";
+
+    assert( logSpy.calledOnce );
+    assert( logSpy.calledWith( table, params ) );
+
+  } );
 
   test( "should log a warning when a folder is empty", function() {
     var logParams = JSON.parse( JSON.stringify( params ) );

--- a/test/integration/js/player-local-storage-messaging-folder.js
+++ b/test/integration/js/player-local-storage-messaging-folder.js
@@ -1,5 +1,4 @@
-/* global suiteSetup, suite, setup, teardown, test, assert,
- RiseVision, sinon */
+/* global suiteSetup, suite, setup, teardown, test, assert, sinon */
 
 /* eslint-disable func-names */
 
@@ -80,7 +79,20 @@ suite( "startup errors", function() {
     assert.equal( document.querySelector( ".message" ).innerHTML, "Rise Storage subscription is not active." );
   } );
 
-  test( "folder does not exist", function() {
+} );
+
+suite( "files downloading", function() {
+
+  setup( function() {
+    clock = sinon.useFakeTimers();
+  } );
+
+  teardown( function() {
+    clock.restore();
+  } );
+
+  test( "should show message after 15 seconds of processing", function() {
+
     // mock receiving client-list message
     messageHandlers.forEach( function( handler ) {
       handler( {
@@ -97,46 +109,6 @@ suite( "startup errors", function() {
         userFriendlyStatus: "authorized"
       } );
     } );
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "file-update",
-        filePath: folderPath,
-        status: "NOEXIST"
-      } );
-    } );
-
-    assert.equal( document.querySelector( ".message" ).innerHTML, "The selected folder does not exist or has been moved to Trash." );
-
-  } );
-
-  test( "folder is empty", function() {
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "file-update",
-        filePath: folderPath,
-        status: "EMPTYFOLDER"
-      } );
-    } );
-
-    assert.equal( document.querySelector( ".message" ).innerHTML, "The selected folder does not contain any images." );
-
-  } );
-
-} );
-
-suite( "files downloading", function() {
-
-  setup( function() {
-    clock = sinon.useFakeTimers();
-  } );
-
-  teardown( function() {
-    clock.restore();
-  } );
-
-  test( "should show message after 15 seconds of processing", function() {
 
     // files are getting processed, starts the initial processing timer
     messageHandlers.forEach( function( handler ) {
@@ -160,74 +132,6 @@ suite( "files downloading", function() {
 
     assert.equal( document.querySelector( ".message" ).innerHTML, "Files are downloading." );
 
-  } );
-
-} );
-
-suite( "file error", function() {
-
-  setup( function() {
-    sinon.stub( RiseVision.ImageRLS, "onFileInit" );
-    sinon.stub( RiseVision.ImageRLS, "onFileRefresh" );
-    clock = sinon.useFakeTimers();
-  } );
-
-  teardown( function() {
-    RiseVision.ImageRLS.onFileInit.restore();
-    RiseVision.ImageRLS.onFileRefresh.restore();
-    clock.restore();
-  } );
-
-  test( "should display message when all files in error", function() {
-    var spy = sinon.spy( RiseVision.ImageRLS, "play" );
-
-    // successfully initialize widget and clear messages
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "FILE-UPDATE",
-        filePath: folderPath + "test-file.jpg",
-        status: "CURRENT",
-        ospath: "path/to/file/abc123",
-        osurl: "file:///path/to/file/abc123"
-      } );
-    } );
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "FILE-UPDATE",
-        filePath: folderPath + "test-file-2.jpg",
-        status: "CURRENT",
-        ospath: "path/to/file/def456",
-        osurl: "file:///path/to/file/def456"
-      } );
-    } );
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "file-error",
-        filePath: folderPath + "test-file.jpg",
-        msg: "File's host server could not be reached",
-        detail: "error details"
-      } );
-    } );
-
-    messageHandlers.forEach( function( handler ) {
-      handler( {
-        topic: "file-error",
-        filePath: folderPath + "test-file-2.jpg",
-        msg: "File's host server could not be reached",
-        detail: "error details"
-      } );
-    } );
-
-    assert.equal( document.querySelector( ".message" ).innerHTML, "Unable to display any files." );
-
-    clock.tick( 4500 );
-    assert( spy.notCalled );
-    clock.tick( 500 );
-    assert( spy.calledOnce );
-
-    RiseVision.ImageRLS.play.restore();
   } );
 
 } );


### PR DESCRIPTION
- In either situation of folder doesn't exist or folder is empty, behaviour now is to continue to log to BQ but immediately notify Viewer `done` and do not display anything on screen. 
- Downgrading folder doesn't exist scenario to a warning, it shouldn't impact our reliability as it is a user controlled scenario. 
Fix for issue https://github.com/Rise-Vision/rise-launcher-electron/issues/773