### PR TITLE
Destroy slider when files go from 1 to 0

### DIFF
--- a/src/widget/image-rls.js
+++ b/src/widget/image-rls.js
@@ -150,7 +150,7 @@ RiseVision.ImageRLS = ( function( gadgets ) {
 
       setSingleImage( urls );
     } else if ( _imageUtils.getMode() === "folder" ) {
-      if ( _errorFlag ) {
+      if ( _errorFlag || _folderUnavailableFlag ) {
         _slider.init( urls );
       } else {
         _slider.refresh( urls );
@@ -186,6 +186,12 @@ RiseVision.ImageRLS = ( function( gadgets ) {
   }
 
   function onSliderReady() {
+    if ( _folderUnavailableFlag ) {
+      // onSliderReady can be triggered from previously having 1 file to show, now there's none, destroy slider
+      _slider.destroy();
+      return;
+    }
+
     _message.hide();
 
     if ( !_viewerPaused ) {


### PR DESCRIPTION
- When slider is refreshed with 1 file, it needs to destroy itself and recreate so that the instance is initialized with 1 file in order for the interactive arrows to be removed. When the slider is ready, it informs so. The fix now checks at that point if folder is completely unavailable (no files), and if so, ensure to destroy the slider completely instead of playing it. 
- Validated with https://apps.risevision.com/editor/workspace/dce2352c-c43f-4bf0-a219-6e2c94f9d3f1/?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013 