### PR TITLE
Fix/chrome 80 folder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "jquery": "~3.3.1",
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.14.0",
     "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.1.0",
-    "webcomponentsjs": "v1.1.0",
+    "webcomponentsjs": "v0.7.24",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.9.3",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
@@ -43,6 +43,6 @@
     "font-awesome": "~4.7.0",
     "lodash": "~4.17.15",
     "jquery": "~3.3.1",
-    "webcomponentsjs": "v1.1.0"
+    "webcomponentsjs": "v0.7.24"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -204,7 +204,7 @@
   });
 
   gulp.task("test", function(cb) {
-    runSequence("version", "es6-modules", "test:unit", "test:e2e", cb);
+    runSequence("version", "es6-modules", "test:unit", "test:e2e", "test:integration", cb);
   });
 
   gulp.task("bower-update", function (cb) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -204,7 +204,7 @@
   });
 
   gulp.task("test", function(cb) {
-    runSequence("version", "es6-modules", "test:unit", "test:e2e", "test:integration", cb);
+    runSequence("version", "es6-modules", "test:unit", "test:e2e", cb);
   });
 
   gulp.task("bower-update", function (cb) {

--- a/src/widget.html
+++ b/src/widget.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Image Widget</title>
 
+  <script src="components/webcomponentsjs/webcomponents.js"></script>
+
   <link rel="stylesheet" href="scripts/slider-revolution/css/style.css">
   <link rel="stylesheet" href="scripts/slider-revolution/css/settings.css">
 

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -1,5 +1,4 @@
 /* global RiseVision, gadgets, config, version */
-/* eslint-disable no-unused-vars */
 ( function( window, document, gadgets ) {
   "use strict";
 
@@ -97,7 +96,6 @@
         RiseVision.Common.RiseCache.isRCV2Player( function( isV2 ) {
           var fragment = document.createDocumentFragment(),
             link = document.createElement( "link" ),
-            webcomponents = document.createElement( "script" ),
             href = config.COMPONENTS_PATH + ( ( isV2 ) ? "rise-storage-v2" : "rise-storage" ) + "/rise-storage.html",
             storage = document.createElement( "rise-storage" );
 
@@ -109,11 +107,6 @@
             storage.removeEventListener( "rise-storage-ready", onStorageReady );
             init();
           }
-
-          webcomponents.src = config.COMPONENTS_PATH + "webcomponentsjs/webcomponents.js";
-
-          // add the webcomponents polyfill source to the document head
-          document.getElementsByTagName( "head" )[ 0 ].appendChild( webcomponents );
 
           link.setAttribute( "rel", "import" );
           link.setAttribute( "href", href );
@@ -162,9 +155,9 @@
   }
 
   if ( id && id !== "" ) {
-    // gadgets.rpc.register( "rscmd_play_" + id, play );
-    // gadgets.rpc.register( "rscmd_pause_" + id, pause );
-    // gadgets.rpc.register( "rscmd_stop_" + id, stop );
+    gadgets.rpc.register( "rscmd_play_" + id, play );
+    gadgets.rpc.register( "rscmd_pause_" + id, pause );
+    gadgets.rpc.register( "rscmd_stop_" + id, stop );
     gadgets.rpc.register( "rsparam_set_" + id, configure );
     gadgets.rpc.call( "", "rsparam_get", null, id, [ "companyId", "displayId", "additionalParams" ] );
   }

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -109,7 +109,7 @@
             init();
           }
 
-          webcomponents.src = config.COMPONENTS_PATH + "webcomponentsjs/webcomponents-loader.js";
+          webcomponents.src = config.COMPONENTS_PATH + "webcomponentsjs/webcomponents.js";
 
           // add the webcomponents polyfill source to the document head
           document.getElementsByTagName( "head" )[ 0 ].appendChild( webcomponents );

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -1,4 +1,5 @@
 /* global RiseVision, gadgets, config, version */
+/* eslint-disable no-unused-vars */
 ( function( window, document, gadgets ) {
   "use strict";
 

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -161,9 +161,9 @@
   }
 
   if ( id && id !== "" ) {
-    gadgets.rpc.register( "rscmd_play_" + id, play );
-    gadgets.rpc.register( "rscmd_pause_" + id, pause );
-    gadgets.rpc.register( "rscmd_stop_" + id, stop );
+    // gadgets.rpc.register( "rscmd_play_" + id, play );
+    // gadgets.rpc.register( "rscmd_pause_" + id, pause );
+    // gadgets.rpc.register( "rscmd_stop_" + id, stop );
     gadgets.rpc.register( "rsparam_set_" + id, configure );
     gadgets.rpc.call( "", "rsparam_get", null, id, [ "companyId", "displayId", "additionalParams" ] );
   }

--- a/test/integration/js/storage-version.js
+++ b/test/integration/js/storage-version.js
@@ -42,5 +42,5 @@ test( "rise-storage element should be added to body", function() {
 test( "polyfill added to document head", function() {
   var head = document.getElementsByTagName( "head" )[ 0 ];
 
-  assert.isNotNull( head.querySelector( "script[src='" + config.COMPONENTS_PATH + "webcomponentsjs/webcomponents-loader.js'" ) );
+  assert.isNotNull( head.querySelector( "script[src='" + config.COMPONENTS_PATH + "webcomponentsjs/webcomponents.js'" ) );
 } );

--- a/test/integration/js/storage-version.js
+++ b/test/integration/js/storage-version.js
@@ -1,4 +1,4 @@
-/* global suiteSetup, suiteTeardown, test, assert, RiseVision, sinon, config */
+/* global suiteSetup, suiteTeardown, test, assert, RiseVision, sinon */
 
 /* eslint-disable func-names */
 

--- a/test/integration/js/storage-version.js
+++ b/test/integration/js/storage-version.js
@@ -38,9 +38,3 @@ suiteTeardown( function() {
 test( "rise-storage element should be added to body", function() {
   assert.isNotNull( document.querySelector( "rise-storage" ) );
 } );
-
-test( "polyfill added to document head", function() {
-  var head = document.getElementsByTagName( "head" )[ 0 ];
-
-  assert.isNotNull( head.querySelector( "script[src='" + config.COMPONENTS_PATH + "webcomponentsjs/webcomponents.js'" ) );
-} );


### PR DESCRIPTION
## Description
Fixes Chrome 80 incompatibilities

## Motivation and Context
Implements webcomponents polyfills v0.

For some reason, the polyfills needed to be statically included so folder could work.

## How Has This Been Tested?
Manually tested using this presentation ( custom widget ) with all types of image handling ( single, folder and URL )
https://apps.risevision.com/editor/workspace/5f5e8a68-0e06-4095-a882-772bc787be8c?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

I also created this presentation with regular image widget and it's URL manually changed to test to validate that the image resizes correctly in editor ( issue that @fjvallarino had reported ):
https://apps.risevision.com/editor/workspace/624cb743-d8a9-4e28-a1c6-3527e026b173?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

I tested both presentation in Rise Player using this schedule:
https://apps.risevision.com/schedules/details/710a1da0-8e90-43f4-9836-f8dfbdb03fae?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

Both presentations worked ok in both current Chrome and Chrome Beta ( 80 ).

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
    - To be released before Friday
    - Widget will immediately be tested after production deployment.
    - Simple rollback is needed in case of problems.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support, no need to update documentation, no need for additional tests.
