### PR TITLE
Facilitate logging and including environment verifier params

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,10 +28,10 @@
     "common-header": "https://github.com/Rise-Vision/common-header.git#v4.0.0",
     "compare-versions": "3.5.1",
     "jquery": "~3.3.1",
-    "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.14.0",
-    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.1.0",
+    "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#chore/env-verifier-params",
+    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#chore/env-verifier-params",
     "webcomponentsjs": "v0.7.24",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.11.0",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#feature/data-usage",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3"
@@ -43,6 +43,7 @@
     "font-awesome": "~4.7.0",
     "lodash": "~4.17.15",
     "jquery": "~3.3.1",
-    "webcomponentsjs": "v0.7.24"
+    "webcomponentsjs": "v0.7.24",
+    "widget-common": "feature/data-usage"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -28,10 +28,10 @@
     "common-header": "https://github.com/Rise-Vision/common-header.git#v4.0.0",
     "compare-versions": "3.5.1",
     "jquery": "~3.3.1",
-    "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#chore/type-param",
-    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#chore/type-param",
+    "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.15.1",
+    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.2.1",
     "webcomponentsjs": "v0.7.24",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#chore/type-param",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.12.1",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3"

--- a/bower.json
+++ b/bower.json
@@ -28,10 +28,10 @@
     "common-header": "https://github.com/Rise-Vision/common-header.git#v4.0.0",
     "compare-versions": "3.5.1",
     "jquery": "~3.3.1",
-    "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#chore/env-verifier-params",
-    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#chore/env-verifier-params",
+    "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.15.0",
+    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.2.0",
     "webcomponentsjs": "v0.7.24",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#feature/data-usage",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.12.0",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3"
@@ -43,7 +43,6 @@
     "font-awesome": "~4.7.0",
     "lodash": "~4.17.15",
     "jquery": "~3.3.1",
-    "webcomponentsjs": "v0.7.24",
-    "widget-common": "feature/data-usage"
+    "webcomponentsjs": "v0.7.24"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -28,10 +28,10 @@
     "common-header": "https://github.com/Rise-Vision/common-header.git#v4.0.0",
     "compare-versions": "3.5.1",
     "jquery": "~3.3.1",
-    "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.15.0",
-    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.2.0",
+    "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#chore/type-param",
+    "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#chore/type-param",
     "webcomponentsjs": "v0.7.24",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.12.0",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#chore/type-param",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3"
@@ -43,6 +43,7 @@
     "font-awesome": "~4.7.0",
     "lodash": "~4.17.15",
     "jquery": "~3.3.1",
-    "webcomponentsjs": "v0.7.24"
+    "webcomponentsjs": "v0.7.24",
+    "widget-common": "chore/type-param"
   }
 }

--- a/src/widget.html
+++ b/src/widget.html
@@ -51,8 +51,8 @@
   <script src="components/underscore/underscore.js"></script>
   <script src="components/compare-versions/index.js"></script>
   <script src="components/widget-common/dist/config.js"></script>
-  <script src="components/widget-common/dist/logger.js"></script>
   <script src="components/widget-common/dist/common.js"></script>
+  <script src="components/widget-common/dist/logger.js"></script>
   <script src="components/widget-common/dist/rise-cache.js"></script>
   <script src="common-modules/local-messaging.js"></script>
   <script src="common-modules/player-local-storage.js"></script>

--- a/src/widget/storage-file.js
+++ b/src/widget/storage-file.js
@@ -180,7 +180,7 @@ RiseVision.Image.StorageFile = function( params, displayId ) {
     storage.setAttribute( "displayId", displayId );
     storage.setAttribute( "env", config.STORAGE_ENV );
 
-    envVerifierParams && storage.setAttribute( "endpointType", envVerifierParams.endpoint_type );
+    envVerifierParams && storage.setAttribute( "endpointType", envVerifierParams.env );
     envVerifierParams && storage.setAttribute( "viewerId", envVerifierParams.viewer_id );
 
     storage.go();

--- a/src/widget/storage-file.js
+++ b/src/widget/storage-file.js
@@ -16,7 +16,7 @@ RiseVision.Image.StorageFile = function( params, displayId ) {
    */
   function init() {
     var storage = document.querySelector( "rise-storage" ),
-      envVerifierParams = utils.getEnvVerifierParams();
+      viewerParams = utils.getViewerParams();
 
     storage.addEventListener( "rise-storage-response", function( e ) {
       var url;
@@ -180,8 +180,9 @@ RiseVision.Image.StorageFile = function( params, displayId ) {
     storage.setAttribute( "displayId", displayId );
     storage.setAttribute( "env", config.STORAGE_ENV );
 
-    envVerifierParams && storage.setAttribute( "endpointType", envVerifierParams.env );
-    envVerifierParams && storage.setAttribute( "viewerId", envVerifierParams.viewer_id );
+    viewerParams && storage.setAttribute( "viewerEnv", viewerParams.viewer_env );
+    viewerParams && storage.setAttribute( "viewerId", viewerParams.viewer_id );
+    viewerParams && storage.setAttribute( "viewerType", viewerParams.viewer_type );
 
     storage.go();
   }

--- a/src/widget/storage-file.js
+++ b/src/widget/storage-file.js
@@ -15,7 +15,8 @@ RiseVision.Image.StorageFile = function( params, displayId ) {
    *  Public Methods
    */
   function init() {
-    var storage = document.querySelector( "rise-storage" );
+    var storage = document.querySelector( "rise-storage" ),
+      envVerifierParams = utils.getEnvVerifierParams();
 
     storage.addEventListener( "rise-storage-response", function( e ) {
       var url;
@@ -178,6 +179,10 @@ RiseVision.Image.StorageFile = function( params, displayId ) {
     storage.setAttribute( "companyId", params.storage.companyId );
     storage.setAttribute( "displayId", displayId );
     storage.setAttribute( "env", config.STORAGE_ENV );
+
+    envVerifierParams && storage.setAttribute( "endpointType", envVerifierParams.endpoint_type );
+    envVerifierParams && storage.setAttribute( "viewerId", envVerifierParams.viewer_id );
+
     storage.go();
   }
 

--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -225,7 +225,7 @@ RiseVision.Image.StorageFolder = function( data, displayId ) {
     storage.setAttribute( "folder", data.storage.folder );
     storage.setAttribute( "env", config.STORAGE_ENV );
 
-    envVerifierParams && storage.setAttribute( "endpointType", envVerifierParams.endpoint_type );
+    envVerifierParams && storage.setAttribute( "endpointType", envVerifierParams.env );
     envVerifierParams && storage.setAttribute( "viewerId", envVerifierParams.viewer_id );
 
     storage.go();

--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -93,7 +93,7 @@ RiseVision.Image.StorageFolder = function( data, displayId ) {
    */
   function init() {
     var storage = document.querySelector( "rise-storage" ),
-      envVerifierParams = utils.getEnvVerifierParams();
+      viewerParams = utils.getViewerParams();
 
     storage.addEventListener( "rise-storage-response", handleResponse );
 
@@ -225,8 +225,9 @@ RiseVision.Image.StorageFolder = function( data, displayId ) {
     storage.setAttribute( "folder", data.storage.folder );
     storage.setAttribute( "env", config.STORAGE_ENV );
 
-    envVerifierParams && storage.setAttribute( "endpointType", envVerifierParams.env );
-    envVerifierParams && storage.setAttribute( "viewerId", envVerifierParams.viewer_id );
+    viewerParams && storage.setAttribute( "viewerEnv", viewerParams.viewer_env );
+    viewerParams && storage.setAttribute( "viewerId", viewerParams.viewer_id );
+    viewerParams && storage.setAttribute( "viewerType", viewerParams.viewer_type );
 
     storage.go();
   }

--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -92,7 +92,8 @@ RiseVision.Image.StorageFolder = function( data, displayId ) {
    *  Public Methods
    */
   function init() {
-    var storage = document.querySelector( "rise-storage" );
+    var storage = document.querySelector( "rise-storage" ),
+      envVerifierParams = utils.getEnvVerifierParams();
 
     storage.addEventListener( "rise-storage-response", handleResponse );
 
@@ -223,6 +224,9 @@ RiseVision.Image.StorageFolder = function( data, displayId ) {
     storage.setAttribute( "displayId", displayId );
     storage.setAttribute( "folder", data.storage.folder );
     storage.setAttribute( "env", config.STORAGE_ENV );
+
+    envVerifierParams && storage.setAttribute( "endpointType", envVerifierParams.endpoint_type );
+    envVerifierParams && storage.setAttribute( "viewerId", envVerifierParams.viewer_id );
 
     storage.go();
   }


### PR DESCRIPTION
## Description
Facilitate logging `env` and `viewerId` values acquired from window url (or parent) 

Apply the env verifier params to the attributes of storage web component to facilitate those params being included in the GCS request. 

## Motivation and Context
Data Usage Analysis

## How Has This Been Tested?
Manually tested with staged version of Widget. Logs to widget table in BQ validated in below screenshot 

![image](https://user-images.githubusercontent.com/7407007/93905042-8435d280-fcc8-11ea-8a3e-df8440e55a9c.png)

Validated storage logs have params added to request

![image](https://user-images.githubusercontent.com/7407007/93920530-4e4f1900-fcdd-11ea-972e-4b801abddc1d.png)


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
