### PR TITLE
Fix and turn back on integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The Image Widget allows you to add an image directly into your Presentation.",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "gulp test:unit",
+    "test": "gulp test",
     "build": "gulp build && ./include-deps.sh",
     "build-dev": "gulp build-dev && ./include-deps.sh"
   },

--- a/test/integration/image-utils.html
+++ b/test/integration/image-utils.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/js/storage-file-stubs.js
+++ b/test/integration/js/storage-file-stubs.js
@@ -2,18 +2,9 @@
 
 /* eslint-disable func-names, no-global-assign */
 
-var xhr;
-
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
-  requests = [];
-  xhr = sinon.useFakeXMLHttpRequest();
-
-  xhr.onCreate = function( xhr ) {
-    requests.push( xhr );
-  };
-
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback );
+  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-file-stubs.js
+++ b/test/integration/js/storage-file-stubs.js
@@ -1,10 +1,10 @@
-/* global RiseVision, sinon, requests, storage */
+/* global RiseVision, sinon, storage, isV2Running */
 
 /* eslint-disable func-names, no-global-assign */
 
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
+  RiseVision.Common.RiseCache.isV2Running( callback( isV2Running ) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-file.js
+++ b/test/integration/js/storage-file.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suite, setup, teardown, test, assert,
+/* global suiteSetup, suite, setup, teardown, test, assert,
  RiseVision, sinon, config */
 
 /* eslint-disable func-names */
@@ -6,7 +6,6 @@
 var ready = false,
   isV2Running = false,
   refreshSpy = null,
-  requests,
   storage,
   check = function( done ) {
     if ( ready ) {

--- a/test/integration/js/storage-file.js
+++ b/test/integration/js/storage-file.js
@@ -19,13 +19,6 @@ var ready = false,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  } else {
-    requests[ 0 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/storage-folder-one-file.js
+++ b/test/integration/js/storage-folder-one-file.js
@@ -1,10 +1,9 @@
-/* global requests, suiteSetup, suite, test, assert, suiteTeardown */
+/* global suiteSetup, suite, test, assert, suiteTeardown */
 
 /* eslint-disable func-names */
 
 var ready = false,
-  isV2Running = false,
-  requests,
+  isV2Running = false, // eslint-disable-line no-unused-vars
   storage,
   check = function( done ) {
     if ( ready ) {

--- a/test/integration/js/storage-folder-one-file.js
+++ b/test/integration/js/storage-folder-one-file.js
@@ -17,13 +17,6 @@ var ready = false,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  } else {
-    requests[ 0 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/storage-folder-stubs.js
+++ b/test/integration/js/storage-folder-stubs.js
@@ -2,19 +2,9 @@
 
 /* eslint-disable func-names, no-global-assign */
 
-var xhr;
-
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
-  xhr = sinon.useFakeXMLHttpRequest();
-
-  xhr.onCreate = function( xhr ) {
-    requests.push( xhr );
-  };
-
-  requests = [];
-
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback );
+  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-folder-stubs.js
+++ b/test/integration/js/storage-folder-stubs.js
@@ -1,10 +1,10 @@
-/* global RiseVision, sinon, requests, storage */
+/* global RiseVision, sinon, storage, isV2Running */
 
 /* eslint-disable func-names, no-global-assign */
 
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
+  RiseVision.Common.RiseCache.isV2Running( callback( isV2Running ) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-folder.js
+++ b/test/integration/js/storage-folder.js
@@ -17,13 +17,6 @@ var ready = false,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  } else {
-    requests[ 0 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/storage-folder.js
+++ b/test/integration/js/storage-folder.js
@@ -1,10 +1,9 @@
-/* global requests, suiteSetup, suite, suiteTeardown, setup, teardown, test, assert, RiseVision, sinon, config */
+/* global suiteSetup, suite, suiteTeardown, setup, teardown, test, assert, RiseVision, sinon, config */
 
 /* eslint-disable func-names */
 
 var ready = false,
   isV2Running = false,
-  requests,
   storage,
   check = function( done ) {
     if ( ready ) {

--- a/test/integration/js/storage-logging-file-stubs.js
+++ b/test/integration/js/storage-logging-file-stubs.js
@@ -2,18 +2,9 @@
 
 /* eslint-disable func-names, no-global-assign */
 
-var xhr;
-
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
-  requests = [];
-  xhr = sinon.useFakeXMLHttpRequest();
-
-  xhr.onCreate = function( xhr ) {
-    requests.push( xhr );
-  };
-
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback );
+  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-logging-file-stubs.js
+++ b/test/integration/js/storage-logging-file-stubs.js
@@ -1,10 +1,10 @@
-/* global RiseVision, sinon, requests, storage */
+/* global RiseVision, sinon, storage, isV2Running */
 
 /* eslint-disable func-names, no-global-assign */
 
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
+  RiseVision.Common.RiseCache.isV2Running( callback( isV2Running ) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-logging-file.js
+++ b/test/integration/js/storage-logging-file.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suite, teardown, test, assert, RiseVision, sinon */
+/* global suiteSetup, suite, teardown, test, assert, RiseVision, sinon */
 
 /* eslint-disable func-names */
 
@@ -16,7 +16,6 @@ var table = "image_events",
   },
   ready = false,
   isV2Running = false,
-  requests,
   storage,
   spy,
   check = function( done ) {

--- a/test/integration/js/storage-logging-file.js
+++ b/test/integration/js/storage-logging-file.js
@@ -32,13 +32,6 @@ var table = "image_events",
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  } else {
-    requests[ 0 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/storage-logging-folder-stubs.js
+++ b/test/integration/js/storage-logging-folder-stubs.js
@@ -2,19 +2,9 @@
 
 /* eslint-disable func-names, no-global-assign */
 
-var xhr;
-
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
-  xhr = sinon.useFakeXMLHttpRequest();
-
-  xhr.onCreate = function( xhr ) {
-    requests.push( xhr );
-  };
-
-  requests = [];
-
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback );
+  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-logging-folder-stubs.js
+++ b/test/integration/js/storage-logging-folder-stubs.js
@@ -1,10 +1,10 @@
-/* global RiseVision, sinon, requests, storage */
+/* global RiseVision, sinon, storage, isV2Running */
 
 /* eslint-disable func-names, no-global-assign */
 
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
+  RiseVision.Common.RiseCache.isV2Running( callback( isV2Running ) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-logging-folder.js
+++ b/test/integration/js/storage-logging-folder.js
@@ -1,4 +1,4 @@
-/* global requests, suiteSetup, suite, suiteTeardown, teardown, test, assert, RiseVision, sinon */
+/* global suiteSetup, suite, suiteTeardown, teardown, test, assert, RiseVision, sinon */
 
 /* eslint-disable func-names */
 
@@ -14,7 +14,6 @@ var table = "image_events",
   },
   ready = false,
   isV2Running = false,
-  requests,
   storage,
   spy,
   clock,

--- a/test/integration/js/storage-logging-folder.js
+++ b/test/integration/js/storage-logging-folder.js
@@ -32,13 +32,6 @@ var table = "image_events",
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  } else {
-    requests[ 0 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/storage-messaging-file-stubs.js
+++ b/test/integration/js/storage-messaging-file-stubs.js
@@ -2,19 +2,9 @@
 
 /* eslint-disable func-names, no-global-assign */
 
-var xhr;
-
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
-  xhr = sinon.useFakeXMLHttpRequest();
-
-  xhr.onCreate = function( xhr ) {
-    requests.push( xhr );
-  };
-
-  requests = [];
-
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback );
+  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-messaging-file-stubs.js
+++ b/test/integration/js/storage-messaging-file-stubs.js
@@ -1,10 +1,10 @@
-/* global RiseVision, sinon, requests, storage */
+/* global RiseVision, sinon, storage, isV2Running */
 
 /* eslint-disable func-names, no-global-assign */
 
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
+  RiseVision.Common.RiseCache.isV2Running( callback( isV2Running ) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-messaging-file.js
+++ b/test/integration/js/storage-messaging-file.js
@@ -1,10 +1,9 @@
-/* global requests, suiteSetup, suite, test, assert, RiseVision, sinon */
+/* global suiteSetup, suite, test, assert, RiseVision, sinon */
 
 /* eslint-disable func-names */
 
 var ready = false,
   isV2Running = false,
-  requests,
   storage,
   check = function( done ) {
     if ( ready ) {

--- a/test/integration/js/storage-messaging-file.js
+++ b/test/integration/js/storage-messaging-file.js
@@ -17,13 +17,6 @@ var ready = false,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  } else {
-    requests[ 0 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/storage-messaging-folder-stubs.js
+++ b/test/integration/js/storage-messaging-folder-stubs.js
@@ -2,19 +2,9 @@
 
 /* eslint-disable func-names, no-global-assign */
 
-var xhr;
-
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
-  xhr = sinon.useFakeXMLHttpRequest();
-
-  xhr.onCreate = function( xhr ) {
-    requests.push( xhr );
-  };
-
-  requests = [];
-
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback );
+  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-messaging-folder-stubs.js
+++ b/test/integration/js/storage-messaging-folder-stubs.js
@@ -1,10 +1,10 @@
-/* global RiseVision, sinon, requests, storage */
+/* global RiseVision, sinon, storage, isV2Running */
 
 /* eslint-disable func-names, no-global-assign */
 
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
+  RiseVision.Common.RiseCache.isV2Running( callback( isV2Running ) );
 } );
 
 sinon.stub( RiseVision.Image, "setAdditionalParams", function( params, mode, displayId ) {

--- a/test/integration/js/storage-messaging-folder.js
+++ b/test/integration/js/storage-messaging-folder.js
@@ -17,13 +17,6 @@ var ready = false,
   };
 
 suiteSetup( function( done ) {
-  if ( isV2Running ) {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  } else {
-    requests[ 0 ].respond( 200 );
-  }
-
   check( done );
 } );
 

--- a/test/integration/js/storage-messaging-folder.js
+++ b/test/integration/js/storage-messaging-folder.js
@@ -1,10 +1,9 @@
-/* global requests, suiteSetup, suiteTeardown, suite, test, assert, RiseVision, sinon */
+/* global suiteSetup, suiteTeardown, suite, test, assert, RiseVision, sinon */
 
 /* eslint-disable func-names */
 
 var ready = false,
   isV2Running = false,
-  requests,
   storage,
   check = function( done ) {
     if ( ready ) {

--- a/test/integration/js/storage-version.js
+++ b/test/integration/js/storage-version.js
@@ -1,27 +1,15 @@
-/* global suiteSetup, suiteTeardown, test, assert, RiseVision, sinon */
+/* global suiteTeardown, test, assert, RiseVision, sinon */
 
 /* eslint-disable func-names */
 
-var isV2Running = false,
-  xhr,
-  requests;
+var isV2Running = false;
 
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
   sinon.stub( RiseVision.Image, "setAdditionalParams" );
 
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
+  RiseVision.Common.RiseCache.isV2Running( callback( isV2Running ) );
 } );
-
-/*suiteSetup( function() {
-  console.log("hello");
-  if ( !isV2Running ) {
-    requests[ 0 ].respond( 200 );
-  } else {
-    requests[ 0 ].respond( 404 );
-    requests[ 1 ].respond( 200 );
-  }
-} );*/
 
 suiteTeardown( function() {
   RiseVision.Image.setAdditionalParams.restore();

--- a/test/integration/js/storage-version.js
+++ b/test/integration/js/storage-version.js
@@ -7,31 +7,23 @@ var isV2Running = false,
   requests;
 
 sinon.stub( RiseVision.Common.RiseCache, "isV2Running", function( callback ) {
-  xhr = sinon.useFakeXMLHttpRequest();
-
-  xhr.onCreate = function( xhr ) {
-    requests.push( xhr );
-  };
-
-  requests = [];
-
   sinon.stub( RiseVision.Image, "setAdditionalParams" );
 
   RiseVision.Common.RiseCache.isV2Running.restore();
-  RiseVision.Common.RiseCache.isV2Running( callback );
+  RiseVision.Common.RiseCache.isV2Running( callback(isV2Running) );
 } );
 
-suiteSetup( function() {
+/*suiteSetup( function() {
+  console.log("hello");
   if ( !isV2Running ) {
     requests[ 0 ].respond( 200 );
   } else {
     requests[ 0 ].respond( 404 );
     requests[ 1 ].respond( 200 );
   }
-} );
+} );*/
 
 suiteTeardown( function() {
-  xhr.restore();
   RiseVision.Image.setAdditionalParams.restore();
 } );
 

--- a/test/integration/non-storage/file.html
+++ b/test/integration/non-storage/file.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>
@@ -55,19 +56,6 @@
       }
     };
 
-    sinon.stub(RiseVision.Common.RiseCache, "isV2Running", function (callback) {
-      xhr = sinon.useFakeXMLHttpRequest();
-
-      xhr.onCreate = function (xhr) {
-        requests.push(xhr);
-      };
-
-      requests = [];
-
-      RiseVision.Common.RiseCache.isV2Running.restore();
-      RiseVision.Common.RiseCache.isV2Running(callback);
-    });
-
     sinon.stub(RiseVision.Image, "setAdditionalParams", function (params, mode, displayId) {
       ready = true;
 
@@ -87,15 +75,7 @@
     });
 
     suiteSetup(function (done) {
-      // Rise Cache V1 not running
-      requests[0].respond(0);
-      requests[1].respond(0);
-
       check(done);
-    });
-
-    suiteTeardown(function() {
-      xhr.restore();
     });
 
     teardown(function () {

--- a/test/integration/non-storage/logging.html
+++ b/test/integration/non-storage/logging.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 
 </head>
@@ -65,19 +66,6 @@
       }
     };
 
-    sinon.stub(RiseVision.Common.RiseCache, "isV2Running", function (callback) {
-      xhr = sinon.useFakeXMLHttpRequest();
-
-      xhr.onCreate = function (xhr) {
-        requests.push(xhr);
-      };
-
-      requests = [];
-
-      RiseVision.Common.RiseCache.isV2Running.restore();
-      RiseVision.Common.RiseCache.isV2Running(callback);
-    });
-
     sinon.stub(RiseVision.Image, "setAdditionalParams", function (params, mode, displayId) {
       ready = true;
 
@@ -100,15 +88,7 @@
     });
 
     suiteSetup(function (done) {
-      // Rise Cache V1 not running
-      requests[0].respond(0);
-      requests[1].respond(0);
-
       check(done);
-    });
-
-    suiteTeardown(function() {
-      xhr.restore();
     });
 
     setup(function() {
@@ -156,10 +136,21 @@
 
     suite("non-storage error", function() {
       var nonStorage = new RiseVision.Image.NonStorage({ "url": params.file_url }),
-        riseCache = RiseVision.Common.RiseCache;
+        riseCache = RiseVision.Common.RiseCache,
+        xhr;
 
       setup(function() {
+        xhr = sinon.useFakeXMLHttpRequest();
+
+        xhr.onCreate = function (xhr) {
+          requests.push(xhr);
+        };
+
         requests = [];
+      });
+
+      teardown(function(){
+        xhr.restore();
       });
 
       test("should log a non-storage error", function() {

--- a/test/integration/non-storage/messaging.html
+++ b/test/integration/non-storage/messaging.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 
 </head>
@@ -42,7 +43,7 @@
 
     var ready = false;
 
-    var xhr, requests, storage;
+    var storage;
 
     var check = function(done) {
       if (ready) {
@@ -54,19 +55,6 @@
         }, 1000);
       }
     };
-
-    sinon.stub(RiseVision.Common.RiseCache, "isV2Running", function (callback) {
-      xhr = sinon.useFakeXMLHttpRequest();
-
-      xhr.onCreate = function (xhr) {
-        requests.push(xhr);
-      };
-
-      requests = [];
-
-      RiseVision.Common.RiseCache.isV2Running.restore();
-      RiseVision.Common.RiseCache.isV2Running(callback);
-    });
 
     sinon.stub(RiseVision.Image, "setAdditionalParams", function (params, mode, displayId) {
       ready = true;
@@ -82,15 +70,7 @@
     });
 
     suiteSetup(function (done) {
-      // Rise Cache V1 not running
-      requests[0].respond(0);
-      requests[1].respond(0);
-
       check(done);
-    });
-
-    suiteTeardown(function() {
-      xhr.restore();
     });
 
     suite("downloading message", function() {
@@ -112,12 +92,17 @@
     suite("non-storage error message", function() {
       var nonStorage = new RiseVision.Image.NonStorage({ "url": "http://www.test.com/test.jpg" }),
         riseCache = RiseVision.Common.RiseCache,
-        clock;
-
+        xhr, clock;
 
       setup(function() {
-        requests = [];
+        xhr = sinon.useFakeXMLHttpRequest();
         clock = sinon.useFakeTimers();
+
+        xhr.onCreate = function (xhr) {
+          requests.push(xhr);
+        };
+
+        requests = [];
 
         riseCache.ping(function(){});
         // Rise Cache V1 running
@@ -127,6 +112,7 @@
 
       teardown(function () {
         clock.restore();
+        xhr.restore();
       });
 
       test("should show non-storage error message", function() {

--- a/test/integration/non-storage/pre-merge-file.html
+++ b/test/integration/non-storage/pre-merge-file.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>
@@ -42,7 +43,7 @@
 
     var ready = false;
 
-    var xhr, requests, storage, clock;
+    var storage, clock;
 
     var check = function(done) {
       if (ready) {
@@ -54,19 +55,6 @@
         }, 1000);
       }
     };
-
-    sinon.stub(RiseVision.Common.RiseCache, "isV2Running", function (callback) {
-      xhr = sinon.useFakeXMLHttpRequest();
-
-      xhr.onCreate = function (xhr) {
-        requests.push(xhr);
-      };
-
-      requests = [];
-
-      RiseVision.Common.RiseCache.isV2Running.restore();
-      RiseVision.Common.RiseCache.isV2Running(callback);
-    });
 
     sinon.stub(RiseVision.Image, "setAdditionalParams", function (params, mode, displayId) {
       ready = true;
@@ -87,15 +75,7 @@
     });
 
     suiteSetup(function (done) {
-      // Rise Cache V1 not running
-      requests[0].respond(0);
-      requests[1].respond(0);
-
       check(done);
-    });
-
-    suiteTeardown(function() {
-      xhr.restore();
     });
 
     teardown(function () {

--- a/test/integration/storage-v1/file.html
+++ b/test/integration/storage-v1/file.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v1/folder-one-file.html
+++ b/test/integration/storage-v1/folder-one-file.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v1/folder.html
+++ b/test/integration/storage-v1/folder.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v1/logging-file.html
+++ b/test/integration/storage-v1/logging-file.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v1/logging-folder.html
+++ b/test/integration/storage-v1/logging-folder.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v1/messaging-file.html
+++ b/test/integration/storage-v1/messaging-file.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v1/messaging-folder.html
+++ b/test/integration/storage-v1/messaging-folder.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v1/version.html
+++ b/test/integration/storage-v1/version.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v2/file.html
+++ b/test/integration/storage-v2/file.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v2/folder-one-file.html
+++ b/test/integration/storage-v2/folder-one-file.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v2/folder.html
+++ b/test/integration/storage-v2/folder.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v2/logging-file.html
+++ b/test/integration/storage-v2/logging-file.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v2/logging-folder.html
+++ b/test/integration/storage-v2/logging-folder.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v2/messaging-file.html
+++ b/test/integration/storage-v2/messaging-file.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v2/messaging-folder.html
+++ b/test/integration/storage-v2/messaging-folder.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/integration/storage-v2/version.html
+++ b/test/integration/storage-v2/version.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="../../../src/widget/css/styles.css">
   <link rel="stylesheet" href="../../../src/components/widget-common/dist/css/message.css">
 
+  <script src="../../../src/components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../src/components/web-component-tester/browser.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Description
Integration test HTML files now import the necessary webcomponents polyfill

Refactored integration tests to omit certain request stubs to fix a timing issue as a result of using polyfill

Re-enabled full test coverage to run

## Motivation and Context
We need integration tests to run when making changes to the Widget to ensure reliability.

## How Has This Been Tested?
Locally and via CCI - https://app.circleci.com/pipelines/github/Rise-Vision/widget-image/13/workflows/540e0eca-e221-42eb-aa4d-1b71922477cd

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
