### PR TITLE
Use content sentinel for type 'webplayer'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "rise-storage": "https://github.com/Rise-Vision/web-component-rise-storage.git#1.15.1",
     "rise-storage-v2": "https://github.com/Rise-Vision/rise-storage.git#2.2.1",
     "webcomponentsjs": "v0.7.24",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.14.0",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.14.1",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2",
     "underscore": "~1.8.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,30 +10,30 @@
       "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.13.10"
+        "@babel/highlight": "7.14.0"
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
-      "integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz",
+      "integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz",
-      "integrity": "sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
+      "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.13",
-        "@babel/generator": "7.13.9",
-        "@babel/helper-compilation-targets": "7.13.13",
-        "@babel/helper-module-transforms": "7.13.14",
-        "@babel/helpers": "7.13.10",
-        "@babel/parser": "7.13.15",
+        "@babel/generator": "7.14.3",
+        "@babel/helper-compilation-targets": "7.13.16",
+        "@babel/helper-module-transforms": "7.14.2",
+        "@babel/helpers": "7.14.0",
+        "@babel/parser": "7.14.3",
         "@babel/template": "7.12.13",
-        "@babel/traverse": "7.13.15",
-        "@babel/types": "7.13.14",
+        "@babel/traverse": "7.14.2",
+        "@babel/types": "7.14.2",
         "convert-source-map": "1.7.0",
         "debug": "4.3.1",
         "gensync": "1.0.0-beta.2",
@@ -81,12 +81,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
+      "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.13.14",
+        "@babel/types": "7.14.2",
         "jsesc": "2.5.2",
         "source-map": "0.5.7"
       },
@@ -100,41 +100,29 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
-      "integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+      "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "7.13.15",
+        "@babel/compat-data": "7.14.0",
         "@babel/helper-validator-option": "7.12.17",
-        "browserslist": "4.16.4",
+        "browserslist": "4.16.6",
         "semver": "6.3.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.16.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
-          "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
+          "version": "4.16.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+          "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30001211",
+            "caniuse-lite": "1.0.30001228",
             "colorette": "1.2.2",
-            "electron-to-chromium": "1.3.717",
+            "electron-to-chromium": "1.3.730",
             "escalade": "3.1.1",
-            "node-releases": "1.1.71"
+            "node-releases": "1.1.72"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001211",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001211.tgz",
-          "integrity": "sha512-v3GXWKofIkN3PkSidLI5d1oqeKNsam9nQkqieoMhP87nxOY0RPDC8X2+jcv8pjV4dRozPLSoMqNii9sDViOlIg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.717",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
-          "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
-          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -145,14 +133,14 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
+      "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
       "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "7.12.13",
         "@babel/template": "7.12.13",
-        "@babel/types": "7.13.14"
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -161,7 +149,7 @@
       "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.13.14"
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -170,7 +158,7 @@
       "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.13.14"
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/helper-module-imports": {
@@ -179,23 +167,23 @@
       "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.13.14"
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.13.14",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
-      "integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
+      "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "7.13.12",
-        "@babel/helper-replace-supers": "7.13.12",
+        "@babel/helper-replace-supers": "7.14.3",
         "@babel/helper-simple-access": "7.13.12",
         "@babel/helper-split-export-declaration": "7.12.13",
-        "@babel/helper-validator-identifier": "7.12.11",
+        "@babel/helper-validator-identifier": "7.14.0",
         "@babel/template": "7.12.13",
-        "@babel/traverse": "7.13.15",
-        "@babel/types": "7.13.14"
+        "@babel/traverse": "7.14.2",
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -204,19 +192,19 @@
       "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.13.14"
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
-      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.3.tgz",
+      "integrity": "sha512-Rlh8qEWZSTfdz+tgNV/N4gz1a0TMNwCUcENhMjHTHKp3LseYH5Jha0NSlyTQWMnjbYcwFt+bqAMqSLHVXkQ6UA==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "7.13.12",
         "@babel/helper-optimise-call-expression": "7.12.13",
-        "@babel/traverse": "7.13.15",
-        "@babel/types": "7.13.14"
+        "@babel/traverse": "7.14.2",
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/helper-simple-access": {
@@ -225,7 +213,7 @@
       "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.13.14"
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -234,13 +222,13 @@
       "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.13.14"
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -250,23 +238,23 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-      "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
+      "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
       "dev": true,
       "requires": {
         "@babel/template": "7.12.13",
-        "@babel/traverse": "7.13.15",
-        "@babel/types": "7.13.14"
+        "@babel/traverse": "7.14.2",
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "7.12.11",
+        "@babel/helper-validator-identifier": "7.14.0",
         "chalk": "2.4.2",
         "js-tokens": "4.0.0"
       },
@@ -309,9 +297,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
-      "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.3.tgz",
+      "integrity": "sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ==",
       "dev": true
     },
     "@babel/template": {
@@ -321,22 +309,22 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.13",
-        "@babel/parser": "7.13.15",
-        "@babel/types": "7.13.14"
+        "@babel/parser": "7.14.3",
+        "@babel/types": "7.14.2"
       }
     },
     "@babel/traverse": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
-      "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
+      "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.13",
-        "@babel/generator": "7.13.9",
-        "@babel/helper-function-name": "7.12.13",
+        "@babel/generator": "7.14.3",
+        "@babel/helper-function-name": "7.14.2",
         "@babel/helper-split-export-declaration": "7.12.13",
-        "@babel/parser": "7.13.15",
-        "@babel/types": "7.13.14",
+        "@babel/parser": "7.14.3",
+        "@babel/types": "7.14.2",
         "debug": "4.3.1",
         "globals": "11.12.0"
       },
@@ -365,13 +353,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.13.14",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
-      "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
+      "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "7.12.11",
-        "lodash": "4.17.21",
+        "@babel/helper-validator-identifier": "7.14.0",
         "to-fast-properties": "2.0.0"
       },
       "dependencies": {
@@ -559,7 +546,7 @@
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.29",
+        "mime-types": "2.1.30",
         "negotiator": "0.6.2"
       }
     },
@@ -1022,7 +1009,7 @@
         "commander": "2.20.3",
         "convert-source-map": "1.7.0",
         "fs-readdir-recursive": "1.1.0",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "lodash": "4.17.21",
         "output-file-sync": "1.1.2",
         "path-is-absolute": "1.0.1",
@@ -2038,9 +2025,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "base": {
@@ -2303,7 +2290,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "1.0.2",
         "concat-map": "0.0.1"
       }
     },
@@ -2315,7 +2302,7 @@
       "requires": {
         "expand-range": "1.8.2",
         "preserve": "0.2.0",
-        "repeat-element": "1.1.3"
+        "repeat-element": "1.1.4"
       }
     },
     "browser-stdout": {
@@ -2330,8 +2317,8 @@
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30001204",
-        "electron-to-chromium": "1.3.699"
+        "caniuse-lite": "1.0.30001228",
+        "electron-to-chromium": "1.3.730"
       }
     },
     "browserstack": {
@@ -2507,9 +2494,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001204",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-      "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==",
+      "version": "1.0.30001228",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -3587,9 +3574,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.699",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.699.tgz",
-      "integrity": "sha512-fjt43CPXdPYwD9ybmKbNeLwZBmCVdLY2J5fGZub7/eMPuiqQznOGNXv/wurnpXIlE7ScHnvG9Zi+H4/i6uMKmw==",
+      "version": "1.3.730",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.730.tgz",
+      "integrity": "sha512-1Tr3h09wXhmqXnvDyrRe6MFgTeU0ZXy3+rMJWTrOHh/HNesWwBBrKnMxRJWZ86dzs8qQdw2c7ZE1/qeGHygImA==",
       "dev": true
     },
     "emoji-regex": {
@@ -3638,7 +3625,7 @@
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "dev": true,
           "requires": {
-            "mime-types": "2.1.29",
+            "mime-types": "2.1.30",
             "negotiator": "0.6.1"
           }
         },
@@ -3766,14 +3753,14 @@
         "has-symbols": "1.0.2",
         "is-callable": "1.2.3",
         "is-negative-zero": "2.0.1",
-        "is-regex": "1.1.2",
-        "is-string": "1.0.5",
-        "object-inspect": "1.9.0",
+        "is-regex": "1.1.3",
+        "is-string": "1.0.6",
+        "object-inspect": "1.10.3",
         "object-keys": "1.1.1",
         "object.assign": "4.1.2",
         "string.prototype.trimend": "1.0.4",
         "string.prototype.trimstart": "1.0.4",
-        "unbox-primitive": "1.0.0"
+        "unbox-primitive": "1.0.1"
       },
       "dependencies": {
         "object-keys": {
@@ -3791,8 +3778,8 @@
       "dev": true,
       "requires": {
         "is-callable": "1.2.3",
-        "is-date-object": "1.0.2",
-        "is-symbol": "1.0.3"
+        "is-date-object": "1.0.4",
+        "is-symbol": "1.0.4"
       }
     },
     "es5-ext": {
@@ -4575,7 +4562,7 @@
         "is-number": "2.1.0",
         "isobject": "2.1.0",
         "randomatic": "3.1.1",
-        "repeat-element": "1.1.3",
+        "repeat-element": "1.1.4",
         "repeat-string": "1.6.1"
       }
     },
@@ -4652,7 +4639,7 @@
             "extend-shallow": "2.0.1",
             "fill-range": "4.0.0",
             "isobject": "3.0.1",
-            "repeat-element": "1.1.3",
+            "repeat-element": "1.1.4",
             "snapdragon": "0.8.2",
             "snapdragon-node": "2.1.1",
             "split-string": "3.1.0",
@@ -4979,7 +4966,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "7.1.6"
+            "glob": "7.1.7"
           }
         }
       }
@@ -4991,9 +4978,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
       "dev": true
     },
     "for-in": {
@@ -5041,7 +5028,7 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.8",
-        "mime-types": "2.1.29"
+        "mime-types": "2.1.30"
       }
     },
     "formatio": {
@@ -5223,9 +5210,9 @@
       }
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -6238,7 +6225,7 @@
             "estraverse": "4.3.0",
             "esutils": "2.0.3",
             "file-entry-cache": "2.0.0",
-            "glob": "7.1.6",
+            "glob": "7.1.7",
             "globals": "9.18.0",
             "ignore": "3.3.10",
             "imurmurhash": "0.1.4",
@@ -6398,7 +6385,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "7.1.6"
+            "glob": "7.1.7"
           }
         },
         "run-async": {
@@ -7579,9 +7566,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-escaper": {
@@ -7618,7 +7605,7 @@
       "dev": true,
       "requires": {
         "eventemitter3": "4.0.7",
-        "follow-redirects": "1.13.3",
+        "follow-redirects": "1.14.1",
         "requires-port": "1.0.0"
       }
     },
@@ -7731,7 +7718,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "4.3.2",
-        "chalk": "4.1.0",
+        "chalk": "4.1.1",
         "cli-cursor": "3.1.0",
         "cli-width": "3.0.0",
         "external-editor": "3.1.0",
@@ -7739,7 +7726,7 @@
         "lodash": "4.17.21",
         "mute-stream": "0.0.8",
         "run-async": "2.4.1",
-        "rxjs": "6.6.6",
+        "rxjs": "6.6.7",
         "string-width": "4.2.2",
         "strip-ansi": "6.0.0",
         "through": "2.3.8"
@@ -7761,9 +7748,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "4.3.0",
@@ -7872,9 +7859,9 @@
       "dev": true
     },
     "is-bigint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
       "dev": true
     },
     "is-binary-path": {
@@ -7887,9 +7874,9 @@
       }
     },
     "is-boolean-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
       "dev": true,
       "requires": {
         "call-bind": "1.0.2"
@@ -7908,9 +7895,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
       "dev": true,
       "requires": {
         "has": "1.0.3"
@@ -7926,9 +7913,9 @@
       }
     },
     "is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+      "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
       "dev": true
     },
     "is-descriptor": {
@@ -7990,9 +7977,9 @@
       "dev": true
     },
     "is-generator-function": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
-      "integrity": "sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+      "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A==",
       "dev": true
     },
     "is-glob": {
@@ -8044,9 +8031,9 @@
       }
     },
     "is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
       "dev": true
     },
     "is-obj": {
@@ -8122,9 +8109,9 @@
       "optional": true
     },
     "is-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
       "dev": true,
       "requires": {
         "call-bind": "1.0.2",
@@ -8157,15 +8144,15 @@
       "dev": true
     },
     "is-string": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "dev": true,
       "requires": {
         "has-symbols": "1.0.2"
@@ -8255,7 +8242,7 @@
       "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.13.15",
+        "@babel/core": "7.14.3",
         "@istanbuljs/schema": "0.1.3",
         "istanbul-lib-coverage": "3.0.0",
         "semver": "6.3.0"
@@ -8372,7 +8359,7 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "jasmine-core": "2.8.0"
       }
     },
@@ -8422,7 +8409,7 @@
           "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
           "dev": true,
           "requires": {
-            "glob": "7.1.6",
+            "glob": "7.1.7",
             "lodash": "4.17.21",
             "minimatch": "3.0.4"
           }
@@ -8684,7 +8671,7 @@
         "di": "0.0.1",
         "dom-serialize": "2.2.1",
         "expand-braces": "0.1.2",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "graceful-fs": "4.2.6",
         "http-proxy": "1.18.1",
         "isbinaryfile": "3.0.3",
@@ -8709,7 +8696,7 @@
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "dev": true,
           "requires": {
-            "mime-types": "2.1.29",
+            "mime-types": "2.1.30",
             "negotiator": "0.6.1"
           }
         },
@@ -9115,7 +9102,7 @@
         "debug": "2.6.9",
         "plist": "2.1.0",
         "q": "1.5.1",
-        "underscore": "1.12.1"
+        "underscore": "1.13.1"
       }
     },
     "lazy-cache": {
@@ -9861,16 +9848,16 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
     },
     "mime-types": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
       "requires": {
-        "mime-db": "1.46.0"
+        "mime-db": "1.47.0"
       }
     },
     "mimic-fn": {
@@ -10032,7 +10019,7 @@
       "dev": true,
       "requires": {
         "debug": "4.3.1",
-        "is-string": "1.0.5",
+        "is-string": "1.0.6",
         "lodash.once": "4.1.1",
         "mkdirp": "0.5.5",
         "object-assign": "4.1.1"
@@ -10271,9 +10258,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.71",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
       "dev": true
     },
     "node-status-codes": {
@@ -10282,12 +10269,6 @@
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
       "dev": true,
       "optional": true
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
     },
     "nodegit-promise": {
       "version": "4.0.0",
@@ -10344,7 +10325,7 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.8.8",
+        "hosted-git-info": "2.8.9",
         "resolve": "1.20.0",
         "semver": "5.7.1",
         "validate-npm-package-license": "3.0.4"
@@ -10413,9 +10394,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
       "dev": true
     },
     "object-keys": {
@@ -11008,7 +10989,7 @@
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.8",
-            "mime-types": "2.1.29"
+            "mime-types": "2.1.30"
           }
         },
         "har-validator": {
@@ -11068,7 +11049,7 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.29",
+            "mime-types": "2.1.30",
             "oauth-sign": "0.9.0",
             "performance-now": "2.1.0",
             "qs": "6.5.2",
@@ -11229,7 +11210,7 @@
         "blocking-proxy": "1.0.1",
         "browserstack": "1.6.1",
         "chalk": "1.1.3",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "jasmine": "2.8.0",
         "jasminewd2": "2.2.0",
         "q": "1.4.1",
@@ -11314,7 +11295,7 @@
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.8",
-            "mime-types": "2.1.29"
+            "mime-types": "2.1.30"
           }
         },
         "globby": {
@@ -11325,7 +11306,7 @@
           "requires": {
             "array-union": "1.0.2",
             "arrify": "1.0.1",
-            "glob": "7.1.6",
+            "glob": "7.1.7",
             "object-assign": "4.1.1",
             "pify": "2.3.0",
             "pinkie-promise": "2.0.1"
@@ -11406,7 +11387,7 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.29",
+            "mime-types": "2.1.30",
             "oauth-sign": "0.9.0",
             "performance-now": "2.1.0",
             "qs": "6.5.2",
@@ -11463,7 +11444,7 @@
             "adm-zip": "0.4.16",
             "chalk": "1.1.3",
             "del": "2.2.2",
-            "glob": "7.1.6",
+            "glob": "7.1.7",
             "ini": "1.3.8",
             "minimist": "1.2.5",
             "q": "1.4.1",
@@ -11726,7 +11707,7 @@
             "extend-shallow": "2.0.1",
             "fill-range": "4.0.0",
             "isobject": "3.0.1",
-            "repeat-element": "1.1.3",
+            "repeat-element": "1.1.4",
             "snapdragon": "0.8.2",
             "snapdragon-node": "2.1.1",
             "split-string": "3.1.0",
@@ -12136,9 +12117,9 @@
       "dev": true
     },
     "repeat-element": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
       "dev": true
     },
     "repeat-string": {
@@ -12258,7 +12239,7 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.29",
+        "mime-types": "2.1.30",
         "oauth-sign": "0.8.2",
         "qs": "6.3.2",
         "stringstream": "0.0.6",
@@ -12324,7 +12305,7 @@
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
-        "is-core-module": "2.2.0",
+        "is-core-module": "2.4.0",
         "path-parse": "1.0.6"
       }
     },
@@ -12392,7 +12373,7 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.6"
+        "glob": "7.1.7"
       }
     },
     "run-async": {
@@ -12417,9 +12398,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-      "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "requires": {
         "tslib": "1.14.1"
@@ -12818,7 +12799,7 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "interpret": "1.4.0",
         "rechoir": "0.6.2"
       },
@@ -13226,7 +13207,7 @@
       "dev": true,
       "requires": {
         "spdx-expression-parse": "3.0.1",
-        "spdx-license-ids": "3.0.7"
+        "spdx-license-ids": "3.0.8"
       }
     },
     "spdx-exceptions": {
@@ -13242,13 +13223,13 @@
       "dev": true,
       "requires": {
         "spdx-exceptions": "2.3.0",
-        "spdx-license-ids": "3.0.7"
+        "spdx-license-ids": "3.0.8"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
+      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
       "dev": true
     },
     "spec-xunit-file": {
@@ -13569,7 +13550,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.6"
+            "glob": "7.1.7"
           }
         }
       }
@@ -13781,7 +13762,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.29"
+        "mime-types": "2.1.30"
       }
     },
     "typedarray": {
@@ -13814,9 +13795,9 @@
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
-      "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
       "dev": true,
       "requires": {
         "function-bind": "1.1.1",
@@ -13832,9 +13813,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
       "optional": true
     },
     "underscore.string": {
@@ -14016,7 +13997,7 @@
       "requires": {
         "inherits": "2.0.4",
         "is-arguments": "1.1.0",
-        "is-generator-function": "1.0.8",
+        "is-generator-function": "1.0.9",
         "is-typed-array": "1.1.5",
         "safe-buffer": "5.2.1",
         "which-typed-array": "1.1.4"
@@ -14697,11 +14678,11 @@
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
       "dev": true,
       "requires": {
-        "is-bigint": "1.0.1",
-        "is-boolean-object": "1.1.0",
-        "is-number-object": "1.0.4",
-        "is-string": "1.0.5",
-        "is-symbol": "1.0.3"
+        "is-bigint": "1.0.2",
+        "is-boolean-object": "1.1.1",
+        "is-number-object": "1.0.5",
+        "is-string": "1.0.6",
+        "is-symbol": "1.0.4"
       }
     },
     "which-module": {
@@ -14811,7 +14792,7 @@
         "chai-as-promised": "7.1.1",
         "event-stream": "4.0.1",
         "express": "4.17.1",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "gulp": "3.8.11",
         "gulp-coveralls": "0.1.4",
         "gulp-html-replace": "1.6.2",
@@ -15116,6 +15097,12 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
           "dev": true
         },
         "object-keys": {


### PR DESCRIPTION
## Description
Use latest widget-common, see https://github.com/Rise-Vision/widget-common/pull/173 for changes to support using Content Sentinel if running in `webplayer`

## Motivation and Context
Issue #226 

## How Has This Been Tested?
Validated with staged version of widget in presentation in a schedule for ChrOS display and confirmed with https://widgets.risevision.com/viewer/?type=webplayer&id=74NWXE7JH3TC 

Also validated still working as expected in legacy preview, shared schedule, and display. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
no
