### PR TITLE
Retry loading single image upon load failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2807,7 +2807,7 @@
       "optional": true
     },
     "common-component": {
-      "version": "git://github.com/Rise-Vision/common-component.git#d899295e2f2a39159b77b99dc132a4e810ed7b2a",
+      "version": "git://github.com/Rise-Vision/common-component.git#3dddcfe967afdd43cbfb8cae1f29466d35e17559",
       "dev": true
     },
     "component-bind": {
@@ -10270,6 +10270,12 @@
       "dev": true,
       "optional": true
     },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+      "dev": true
+    },
     "nodegit-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/nodegit-promise/-/nodegit-promise-4.0.0.tgz",
@@ -14821,7 +14827,7 @@
         "reporter-file": "0.0.1",
         "run-sequence": "0.3.7",
         "sinon": "7.5.0",
-        "sinon-chai": "3.6.0",
+        "sinon-chai": "3.7.0",
         "spawn-cmd": "0.0.2",
         "spec-xunit-file": "0.0.1-3",
         "xml2js": "0.4.23",
@@ -15099,12 +15105,6 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-          "dev": true
-        },
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -15156,9 +15156,9 @@
           }
         },
         "sinon-chai": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.6.0.tgz",
-          "integrity": "sha512-bk2h+0xyKnmvazAnc7HE5esttqmCerSMcBtuB2PS2T4tG6x8woXAxZeJaOJWD+8reXHngnXn0RtIbfEW9OTHFg==",
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+          "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
           "dev": true
         },
         "split": {

--- a/src/widget/image-watch.js
+++ b/src/widget/image-watch.js
@@ -17,7 +17,8 @@ RiseVision.ImageWatch = ( function( gadgets ) {
     _configurationLogged = false,
     _unavailableFlag = false,
     _folderUnavailableFlag = false,
-    _img = null;
+    _img = null,
+    _singleImageLoadFailed = false;
 
   /*
    *  Private Methods
@@ -111,11 +112,21 @@ RiseVision.ImageWatch = ( function( gadgets ) {
     }
 
     _img.onload = function() {
+      _singleImageLoadFailed = false;
       _imageUtils.handleSingleImageLoad( url, _viewerPaused );
     };
 
     _img.onerror = function() {
-      _imageUtils.handleSingleImageLoadError( url )
+      if ( !_singleImageLoadFailed ) {
+        _singleImageLoadFailed = true;
+
+        // retry loading the image again before giving up and logging error
+        setTimeout( function() {
+          setSingleImage( url );
+        }, 2000 );
+      } else {
+        _imageUtils.handleSingleImageLoadError( url )
+      }
     };
 
     _img.src = url;

--- a/src/widget/image.js
+++ b/src/widget/image.js
@@ -20,7 +20,8 @@ RiseVision.Image = ( function( gadgets ) {
     _configurationLogged = false,
     _unavailableFlag = false,
     _viewerPaused = true,
-    _img = null;
+    _img = null,
+    _singleImageLoadFailed = false;
 
   /*
    *  Private Methods
@@ -114,11 +115,21 @@ RiseVision.Image = ( function( gadgets ) {
 
   function setSingleImage( url ) {
     _img.onload = function() {
+      _singleImageLoadFailed = false;
       _imageUtils.handleSingleImageLoad( url, _viewerPaused );
     };
 
     _img.onerror = function() {
-      _imageUtils.handleSingleImageLoadError( url )
+      if ( !_singleImageLoadFailed ) {
+        _singleImageLoadFailed = true;
+
+        // retry loading the image again before giving up and logging error
+        setTimeout( function() {
+          setSingleImage( url );
+        }, 2000 );
+      } else {
+        _imageUtils.handleSingleImageLoadError( url )
+      }
     };
 
     // handles special characters


### PR DESCRIPTION
## Description
On the initial browser load attempt of a single file, if it fails, the widget does not log an error. Instead, after two seconds it retries the load again.

Upon failing again, widget logs an error. 

## Motivation and Context
Address issue https://github.com/Rise-Vision/rise-image/issues/98 . The latest [investigation and analysis](https://docs.google.com/document/d/1njpQARG4BskJcsCpgS2ob-emNqVlZmYeszCHavpmuoA/edit#bookmark=id.ns1860to53mq) of defect #98 has informed us that in the majority of cases:

- the file is not corrupt
- the file fails only on first load

Given the above, the best improvement is to not log on an initial failure and allow a chance for recovery on retrying the load. 

## How Has This Been Tested?
Tested with a corrupt JPG file and staged widget and validated the image load is attempted twice 

https://widgets.risevision.com/viewer/?type=sharedschedule&id=822cbbd2-ad76-44c1-acc6-cff355e1c133

![image](https://user-images.githubusercontent.com/7407007/125647118-6b315f91-4dd6-4724-8a7f-472cc9836577.png)


## Release Plan:
- Deploy to production today. 
- Analyze logs over next 2 days.
  - As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
no
